### PR TITLE
Add travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+matrix: 
+  include: 
+  - os: linux  
+    language: python 
+    python: "3.5" 
+    env: PY=python
+    install: 
+    - pip install scipy
+  - os: windows 
+    # does not support python 
+    language: bash 
+    env: PY=py
+    python: "3.5"
+    before_install: choco install python --version 3.5.4 
+    install: 
+      - $PY -m pip install --upgrade pip
+      - $PY -m pip install scipy 
+      - $PY -m pip install --upgrade setuptools
+
+  - os: osx
+    # does not support python
+    language: generic 
+    env: PY=python3
+    install: 
+      - pip3 install scipy
+
+script: 
+  - $PY setup.py test 


### PR DESCRIPTION
This adds basic Travis setup for macOS, Windows and Linux, as described in #24 . 
 Real tests that actually use preCICE instead of mocking it should first be added to `systemtests` repo and then we can trigger it from here, as done for other adapters. 

One should also activate the repo on  Travis in order for everything to work. Just find the repo on your account [page]( https://travis-ci.org/organizations/account/repositories ) (it might be in the `precice` organization subsection) and trigger the switch. 