### PR TITLE
Implementing proper treatment of vector valued data

### DIFF
--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -62,12 +62,16 @@ class CustomExpression(UserExpression):
                 f = Rbf(self._coords_x, self._coords_y, self._vals.flatten())
             elif self.isVectorValues():
                 f = Rbf(self._coords_x, self._coords_y, self._vals[:,dim_no].flatten()) # extract dim_no element of each vector
+            else: # TODO: this is already checked in isScalarValues()!
+                raise Exception("Dimension of the function is 0 or negative!")
             return f(x[0], x[1])
-        if x.__len__() == 3:
+        if x.__len__() == 3: # this case has not been tested yet
             if self.isScalarValues():
                 f = Rbf(self._coords_x, self._coords_y, self._coords_z, self._vals.flatten())
-            if self.isVectorValues():
+            elif self.isVectorValues():
                 f = Rbf(self._coords_x, self._coords_y, self._coords_z, self._vals[:,dim_no].flatten())
+            else: # TODO: this is already checked in isScalarValues()!
+                raise Exception("Dimension of the function is 0 or negative!")
             return f(x[0], x[1], x[2])
 
     def lin_interpol(self, x):
@@ -377,9 +381,10 @@ class Adapter:
         """ Determines if the function is scalar- or vector-valued based on
         rank evaluation.
         """
-        if function.value_rank() == 0:
+        # TODO: is is better to use FunctionType.SCALAR.value here ?
+        if function.value_rank() == 0: # scalar-valued functions have rank 0 is FEniCS
             return FunctionType.SCALAR
-        elif function.value_rank() == 1:
+        elif function.value_rank() == 1: # vector-valued functions have rank 1 in FEniCS
             return FunctionType.VECTOR
         else:
             raise Exception("Error determining function type")

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -101,12 +101,7 @@ class CustomExpression(UserExpression):
         """ Determines if function being interpolated is vector-valued based on
         dimension of provided vals vector
         """
-        if self._vals.ndim > 1:
-            return True
-        elif self._vals.ndim == 1:
-            return False
-        else:
-            raise Exception("Dimension of the function is 0 or negative!")
+        return not self.isScalarValues()
 
 
 class Adapter:

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -274,13 +274,24 @@ class Adapter:
         self._precice_tau = self._interface.initialize()
 
         if self._interface.is_action_required(precice.action_write_initial_data()):
-            self._interface.write_block_scalar_data(self._write_data_id, self._n_vertices, self._vertex_ids, self._write_data)
+            if write_field.value_rank() == 0:
+                self._interface.write_block_scalar_data(self._write_data_id, self._n_vertices, self._vertex_ids, self._write_data)
+            elif write_field.value_rank() == 1:
+                self._interface.write_block_vector_data(self._write_data_id, self._n_vertices, self._vertex_ids, self._write_data)
+            else:
+                raise Exception("Rank of function space is neither 0 nor 1")
             self._interface.fulfilled_action(precice.action_write_initial_data())
 
         self._interface.initialize_data()
 
         if self._interface.is_read_data_available():
-            self._interface.read_block_scalar_data(self._read_data_id, self._n_vertices, self._vertex_ids, self._read_data)
+            if read_field.value_rank() == 0:
+                self._interface.read_block_scalar_data(self._read_data_id, self._n_vertices, self._vertex_ids, self._read_data)
+            elif read_field.value_rank() == 1:
+                self._interface.read_block_vector_data(self._read_data_id, self._n_vertices, self._vertex_ids, self._read_data)
+            else:
+                raise Exception("Rank of function space is neither 0 nor 1")
+
 
         if self._interface.is_action_required(precice.action_write_iteration_checkpoint()):
             self._u_cp = u_n.copy(deepcopy=True)


### PR DESCRIPTION
For testing of the functionality use the structure-structure coupling tutorial proposed in https://github.com/precice/tutorials/pull/27. This PR closes #26 if merged.

# What we currently have

## Do RBF interpolation on every component of vector field.

https://github.com/precice/fenics-adapter/blob/02e00b749bb0e2597a81e3f62e4e652be099cfde/fenicsadapter/fenicsadapter.py#L63-L64

called in `eval`

https://github.com/precice/fenics-adapter/blob/02e00b749bb0e2597a81e3f62e4e652be099cfde/fenicsadapter/fenicsadapter.py#L81-L87

## Check case `SCALAR` and `VECTOR`

New functions implemented. Can be used to determine whether vector or scalar data has to be communicated via preCICE

https://github.com/precice/fenics-adapter/blob/1412a6fdefccb51c60226808350dc2ff115a11b3/fenicsadapter/fenicsadapter.py#L322-L325

## Tested `read_block_vector_data` and `write_block_vector_data`

# Open ToDo's

- [ ] continue implementation of vector data support in `advance`
- [ ] test with structure-structure coupling tutorial proposed in https://github.com/precice/tutorials/pull/27