### PR TITLE
Support FSI with fenics as a Structure Solver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     env: PY=python
     before_install:
     - sudo apt-get install software-properties-common
-    - sudo add-apt-repository ppa:fenics-packages/fenics
+    - sudo add-apt-repository -y ppa:fenics-packages/fenics
     - sudo apt-get update
     - sudo apt-get install --no-install-recommends fenics
     install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix: 
   include: 
   - os: linux  
-    dist: xenial
+    dist: bionic
     language: python
     python: "3.5" 
     env: PY=python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - sudo apt-get install software-properties-common
     - sudo add-apt-repository -y ppa:fenics-packages/fenics
     - sudo apt-get update
-    - sudo apt-get install --no-install-recommends fenics
+    - sudo apt-get install -y --no-install-recommends fenics
     install: 
     - pip install scipy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 matrix: 
   include: 
   - os: linux  
+    name: "Full tests [Linux]"
     language: python
     dist: bionic
     virtualenv:
@@ -15,7 +16,27 @@ matrix:
     install: 
     - pip install scipy
 
+  - os: windows 
+    name: "Mock tests [Windows]"
+    # does not support python 
+    language: bash 
+    env: PY=py
+    python: "3.5"
+    before_install: choco install python --version 3.5.4 
+    install: 
+      - $PY -m pip install --upgrade pip
+      - $PY -m pip install scipy 
+      - $PY -m pip install --upgrade setuptools
+
+  - os: osx
+    name: "Mock tests [OSx]"
+    # does not support python
+    language: generic 
+    env: PY=python3
+    install: 
+      - pip3 install scipy
+
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py
   - $PY -m pip install ./precice/
-  - $PY setup.py test 
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  $PY setup.py test ; else python3 setup.py test -s tests.test_fenicsadapter ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,10 @@ matrix:
     env: PY=python
     install: 
     - pip install scipy
-  - os: windows 
-    # does not support python 
-    language: bash 
-    env: PY=py
-    python: "3.5"
-    before_install: choco install python --version 3.5.4 
-    install: 
-      - $PY -m pip install --upgrade pip
-      - $PY -m pip install scipy 
-      - $PY -m pip install --upgrade setuptools
-
-  - os: osx
-    # does not support python
-    language: generic 
-    env: PY=python3
-    install: 
-      - pip3 install scipy
+    - apt-get install software-properties-common
+    - add-apt-repository ppa:fenics-packages/fenics
+    - apt-get update
+    - apt-get install --no-install-recommends fenics
 
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ matrix:
     language: python 
     python: "3.5" 
     env: PY=python
+    before_install:
+    - sudo apt-get install software-properties-common
+    - sudo add-apt-repository ppa:fenics-packages/fenics
+    - sudo apt-get update
+    - sudo apt-get install --no-install-recommends fenics
     install: 
     - pip install scipy
-    - apt-get install software-properties-common
-    - add-apt-repository ppa:fenics-packages/fenics
-    - apt-get update
-    - apt-get install --no-install-recommends fenics
 
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 matrix: 
   include: 
   - os: linux  
-    language: python 
+    language: python
     python: "3.5" 
-    env: PY=python
+    env: PY=python3
     before_install:
     - sudo apt-get install software-properties-common
     - sudo add-apt-repository -y ppa:fenics-packages/fenics

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ matrix:
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py
   - $PY -m pip install ./precice/
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  $PY setup.py test ; else python3 setup.py test -s tests.test_fenicsadapter ; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  $PY setup.py test ; else $PY setup.py test -s tests.test_fenicsadapter ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix: 
   include: 
   - os: linux  
-    dist: bionic
+    dist: xenial
     language: python
     python: "3.5" 
     env: PY=python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 matrix: 
   include: 
   - os: linux  
-    dist: bionic
     language: python
-    python: "3.6" 
-    env: PY=python3
+    dist: bionic
     virtualenv:
       system_site_packages: true
-    install:
-    - pip3 install scipy
+    python: "3.6" 
+    env: PY=python3
+    before_install:
     - sudo apt-get install software-properties-common
     - sudo add-apt-repository -y ppa:fenics-packages/fenics
     - sudo apt-get update
     - sudo apt-get install -y --no-install-recommends fenics
+    install: 
+    - pip install scipy
 
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 matrix: 
   include: 
   - os: linux  
+    dist: bionic
     language: python
     python: "3.5" 
     env: PY=python3
+    virtualenv:
+      system_site_packages: true
     install:
     - pip3 install scipy
     - sudo apt-get install software-properties-common
     - sudo add-apt-repository -y ppa:fenics-packages/fenics
     - sudo apt-get update
     - sudo apt-get install -y --no-install-recommends fenics
-    - pip3 install fenics-ffc --upgrade
 
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     - sudo add-apt-repository -y ppa:fenics-packages/fenics
     - sudo apt-get update
     - sudo apt-get install -y --no-install-recommends fenics
+    - pip3 install fenics-ffc --upgrade
 
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   - os: linux  
     dist: bionic
     language: python
-    python: "3.5" 
+    python: "3.6" 
     env: PY=python3
     virtualenv:
       system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ matrix:
     language: python
     python: "3.5" 
     env: PY=python3
-    before_install:
+    install:
+    - pip3 install scipy
     - sudo apt-get install software-properties-common
     - sudo add-apt-repository -y ppa:fenics-packages/fenics
     - sudo apt-get update
     - sudo apt-get install -y --no-install-recommends fenics
-    install: 
-    - pip install scipy
 
 script: 
   - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py

--- a/fenicsadapter/__init__.py
+++ b/fenicsadapter/__init__.py
@@ -1,2 +1,2 @@
-from .fenicsadapter import Adapter, CustomExpression
+from .fenicsadapter import Adapter, GeneralInterpolationExpression, ExactInterpolationExpression
 

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -261,9 +261,11 @@ class Adapter:
         self._function_space = None
         self._dss = None  # measure for boundary integral
         
-        # Force-coupling
-        self._x_forces = None # list of PointSources for Forces
-        self._y_forces = None
+        # Force-coupling via PointSource
+        # PointSources are scalar valued, therefore we need an individual scalar valued PointSource for each dimension in a vector-valued setting
+        # TODO: a vector valued PointSource would be more straigthforward, but does not exist (as far as I know)
+        self._x_forces = None # list of PointSources for Forces in x direction
+        self._y_forces = None # list of PointSources for Forces in y direction
         self._force_boundary = None
         
         #Nodes with Dirichlet and Force-boundary

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -334,8 +334,7 @@ class Adapter:
                 self._read_data[:, 0] = precice_read_data[:, 0]
                 self._read_data[:, 1] = precice_read_data[:, 1]
                 # z is the dead direction so it is supposed that the data is close to zero
-                #print(precice_read_data)
-                #assert(np.testing.assert_allclose(precice_read_data[:, 2], np.zeros_like(precice_read_data[:, 2])))
+                np.testing.assert_allclose(precice_read_data[:, 2], np.zeros_like(precice_read_data[:, 2]))
                 assert(np.sum(np.abs(precice_read_data[:,2]))< 1e-8)
             else: 
                 raise Exception("Dimensions don't match.")

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -521,7 +521,7 @@ class Adapter:
             logging.warning("fenics_dimension = {} and precice_dimension = {} do not match!".format(self._fenics_dimensions,
                                                                                             self._dimensions))
             if self._can_apply_2d_3d_coupling():
-                logging.warning("2D-3D coupling will be applied. Y coordinates of all nodes are set to zero.")
+                logging.warning("2D-3D coupling will be applied. Z coordinates of all nodes will be set to zero.")
             else:
                 raise Exception("fenics_dimension = {}, precice_dimension = {}. "
                                 "No proper treatment for dimensional mismatch is implemented. Aborting!".format(

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -319,3 +319,10 @@ class Adapter:
     def finalize(self):
         """Finalizes the coupling interface."""
         self._interface.finalize()
+
+    def get_solver_name(self):
+        """Returns name of this solver as defined in config file.
+
+        :return: Solver name.
+        """
+        return self._solver_name

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -144,8 +144,8 @@ class GeneralInterpolationExpression(CustomExpression):
             if self.is_scalar_valued():  # check if scalar or vector-valued
                 interpolant.append(Rbf(self._coords_x, self._coords_y, self._vals.flatten()))
             elif self.is_vector_valued():
-                interpolant.append(Rbf(self._coords_x, self._coords_y, self._vals[:,0].flatten())) # extract dim_no element of each vector
-                interpolant.append(Rbf(self._coords_x, self._coords_y, self._vals[:,1].flatten())) # extract dim_no element of each vector
+                interpolant.append(Rbf(self._coords_x, self._coords_y, self._vals[:, 0].flatten())) # extract dim_no element of each vector
+                interpolant.append(Rbf(self._coords_x, self._coords_y, self._vals[:, 1].flatten())) # extract dim_no element of each vector
             else:
                 raise Exception("Problem dimension and data dimension not matching.")
         elif self._dimension == 3:
@@ -287,9 +287,10 @@ class Adapter:
         elif self._write_function_type is FunctionType.VECTOR:
                 
                 if self._can_apply_2d_3d_coupling():
+                    # in 2d-3d coupling z dimension is set to zero
                     precice_write_data = np.column_stack((self._write_data[:, 0],
-                                                          np.zeros(self._n_vertices),  # in 2d-3d coupling y dimension is dead
-                                                          self._write_data[:, 1]))
+                                                          self._write_data[:, 1],
+                                                          np.zeros(self._n_vertices)))
 
                     assert(precice_write_data.shape[0] == self._n_vertices and
                            precice_write_data.shape[1] == self._dimensions)
@@ -331,8 +332,9 @@ class Adapter:
                 precice_read_data = np.reshape(precice_data,(self._n_vertices, self._dimensions), 'C')
 
                 self._read_data[:, 0] = precice_read_data[:, 0]
-                self._read_data[:, 1] = precice_read_data[:, 2]
-                # y is the dead direction so it is left out
+                self._read_data[:, 1] = precice_read_data[:, 1]
+                # z is the dead direction so it is supposed that the data is close to zero
+                assert(np.testing.assert_allclose(precice_read_data[:, 2], np.zeros_like(precice_read_data[:, 2])))
             else: 
                 raise Exception("Dimensions don't match.")
         else:
@@ -358,8 +360,8 @@ class Adapter:
                 if self._dimensions == 2:
                     vertices_y.append(v.x(1))
                 elif self._can_apply_2d_3d_coupling():
-                    vertices_z.append(v.x(1))
-                    vertices_y.append(0)
+                    vertices_y.append(v.x(1))
+                    vertices_z.append(0)
                 else:
                     raise Exception("Dimensions do not match!")
 
@@ -520,7 +522,10 @@ class Adapter:
             if self._can_apply_2d_3d_coupling():
                 logging.warning("2D-3D coupling will be applied. Y coordinates of all nodes are set to zero.")
             else:
-                raise Exception("No proper treatment for dimensional mismatch is implemented. Aborting!")
+                raise Exception("fenics_dimension = {}, precice_dimension = {}. "
+                                "No proper treatment for dimensional mismatch is implemented. Aborting!".format(
+                    self._fenics_dimensions,
+                    self._dimensions))
 
         self.set_coupling_mesh(mesh, coupling_subdomain)
         self._set_read_field(read_field)
@@ -567,10 +572,8 @@ class Adapter:
         if self._dimensions == 3:
             vertices_z = vertices[2, :]
 
-        if self._dimensions == 2:
+        if self._dimensions == 2 or self._can_apply_2d_3d_coupling():
             return vertices_x, vertices_y
-        elif self._can_apply_2d_3d_coupling():
-            return vertices_x, vertices_z
         else:
             raise Exception("Error: These Dimensions are not supported by the adapter.")
 

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -334,7 +334,9 @@ class Adapter:
                 self._read_data[:, 0] = precice_read_data[:, 0]
                 self._read_data[:, 1] = precice_read_data[:, 1]
                 # z is the dead direction so it is supposed that the data is close to zero
-                assert(np.testing.assert_allclose(precice_read_data[:, 2], np.zeros_like(precice_read_data[:, 2])))
+                #print(precice_read_data)
+                #assert(np.testing.assert_allclose(precice_read_data[:, 2], np.zeros_like(precice_read_data[:, 2])))
+                assert(np.sum(np.abs(precice_read_data[:,2]))< 1e-8)
             else: 
                 raise Exception("Dimensions don't match.")
         else:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(name='fenics-adapter',
       author_email='benjamin.rueth@tum.de',
       license='LGPL-3.0',
       packages=['fenicsadapter'],
-      install_requires=['precice', 'fenics', 'scipy', 'numpy'],
+      install_requires=['precice', 'fenics', 'scipy', 'numpy>=1.13.3'],
       test_suite='tests',
       zip_safe=False)

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -28,7 +28,7 @@ class TestWriteData(TestCase):
     scalar_V = FunctionSpace(mesh, "P", 2)
     scalar_function = interpolate(scalar_expr, scalar_V)
 
-    vector_expr = Expression(("x[0]*x[0] + x[1]*x[1]", "x[0]*x[0] - x[1]*x[1]"), degree=2)
+    vector_expr = Expression(("x[0] + x[1]*x[1]", "x[0] - x[1]*x[1]"), degree=2)
     vector_V = VectorFunctionSpace(mesh, "P", 2)
     vector_function = interpolate(vector_expr, vector_V)
 
@@ -63,7 +63,7 @@ class TestWriteData(TestCase):
 
         expected_data_id = 15
         expected_size = 11
-        expected_values = np.array([x_right**2 + y**2 for y in np.linspace(y_bottom, y_top, 11)])
+        expected_values = np.array([self.scalar_expr(x_right, y) for y in np.linspace(y_bottom, y_top, 11)])
         expected_ids = np.zeros(11)
 
         expected_args = [expected_data_id, expected_size, expected_ids, expected_values]
@@ -102,8 +102,8 @@ class TestWriteData(TestCase):
 
         expected_data_id = 15
         expected_size = 11
-        expected_values_x = np.array([x_right ** 2 + y ** 2 for y in np.linspace(y_bottom, y_top, 11)])
-        expected_values_y = np.array([x_right ** 2 - y ** 2 for y in np.linspace(y_bottom, y_top, 11)])
+        expected_values_x = np.array([self.vector_expr(x_right, y)[0] for y in np.linspace(y_bottom, y_top, 11)])
+        expected_values_y = np.array([self.vector_expr(x_right, y)[1] for y in np.linspace(y_bottom, y_top, 11)])
         expected_values = np.stack([expected_values_x, expected_values_y]).T.ravel()
         expected_ids = np.zeros(11)
 

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -26,9 +26,11 @@ class TestWriteData(TestCase):
 
     scalar_expr = Expression("x[0]*x[0] + x[1]*x[1]", degree=2)
     scalar_V = FunctionSpace(mesh, "P", 2)
+    scalar_function = interpolate(scalar_expr, scalar_V)
 
     vector_expr = Expression(("x[0]*x[0] + x[1]*x[1]", "x[0]*x[0] - x[1]*x[1]"), degree=2)
     vector_V = VectorFunctionSpace(mesh, "P", 2)
+    vector_function = interpolate(vector_expr, vector_V)
 
     def setUp(self):
         pass
@@ -38,7 +40,7 @@ class TestWriteData(TestCase):
         import fenicsadapter
         Interface.configure = MagicMock()
         Interface.write_block_scalar_data = MagicMock()
-        Interface.read_block_scalar_data = MagicMock()
+        Interface.read_block_vector_data = MagicMock()
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock()
         Interface.initialize = MagicMock()
@@ -50,12 +52,14 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
 
-        write_u = interpolate(self.scalar_expr, self.scalar_V)
+        write_u = self.scalar_function
+        read_u = self.vector_function
+        u_init = self.scalar_function
 
         precice = fenicsadapter.Adapter(self.dummy_config)
         precice._coupling_bc_expression = MagicMock()
-        precice.initialize(RightBoundary(), self.mesh, write_u, write_u, write_u)
-        precice.advance(write_u, write_u, write_u, 0, 0, 0)
+        precice.initialize(RightBoundary(), self.mesh, read_u, write_u, u_init)
+        precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
         expected_size = 11
@@ -75,7 +79,7 @@ class TestWriteData(TestCase):
         import fenicsadapter
         Interface.configure = MagicMock()
         Interface.write_block_vector_data = MagicMock()
-        Interface.read_block_vector_data = MagicMock()
+        Interface.read_block_scalar_data = MagicMock()
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock()
         Interface.initialize = MagicMock()
@@ -87,12 +91,14 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
 
-        write_u = interpolate(self.vector_expr, self.vector_V)
+        write_u = self.vector_function
+        read_u = self.scalar_function
+        u_init = self.vector_function
 
         precice = fenicsadapter.Adapter(self.dummy_config)
         precice._coupling_bc_expression = MagicMock()
-        precice.initialize(RightBoundary(), self.mesh, write_u, write_u, write_u)
-        precice.advance(write_u, write_u, write_u, 0, 0, 0)
+        precice.initialize(RightBoundary(), self.mesh, read_u, write_u, u_init)
+        precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
         expected_size = 11
@@ -118,7 +124,7 @@ class TestWriteData(TestCase):
                 read_data[i] = i
 
         Interface.configure = MagicMock()
-        Interface.write_block_scalar_data = MagicMock()
+        Interface.write_block_vector_data = MagicMock()
         Interface.read_block_scalar_data = MagicMock(side_effect=return_dummy_data)
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock()
@@ -131,12 +137,14 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
 
-        read_u = interpolate(self.scalar_expr, self.scalar_V)
+        write_u = self.vector_function
+        read_u = self.scalar_function
+        u_init = self.vector_function
 
         precice = fenicsadapter.Adapter(self.dummy_config)
         precice._coupling_bc_expression = MagicMock()
-        precice.initialize(RightBoundary(), self.mesh, read_u, read_u, read_u)
-        precice.advance(read_u, read_u, read_u, 0, 0, 0)
+        precice.initialize(RightBoundary(), self.mesh, read_u, write_u, u_init)
+        precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
         expected_size = 11
@@ -160,7 +168,7 @@ class TestWriteData(TestCase):
                 read_data[i] = i
 
         Interface.configure = MagicMock()
-        Interface.write_block_vector_data = MagicMock()
+        Interface.write_block_scalar_data = MagicMock()
         Interface.read_block_vector_data = MagicMock(side_effect=return_dummy_data)
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock()
@@ -173,12 +181,14 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
 
-        read_u = interpolate(self.vector_expr, self.vector_V)
+        write_u = self.scalar_function
+        read_u = self.vector_function
+        u_init = self.scalar_function
 
         precice = fenicsadapter.Adapter(self.dummy_config)
         precice._coupling_bc_expression = MagicMock()
-        precice.initialize(RightBoundary(), self.mesh, read_u, read_u, read_u)
-        precice.advance(read_u, read_u, read_u, 0, 0, 0)
+        precice.initialize(RightBoundary(), self.mesh, read_u, write_u, u_init)
+        precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
         expected_size = 11

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock, patch
+from unittest import TestCase
+import tests.MockedPrecice
+from fenics import Expression, UnitSquareMesh, FunctionSpace, VectorFunctionSpace, interpolate, SubDomain, near
+import numpy as np
+
+
+x_left, x_right = 0, 1
+y_bottom, y_top = 0, 1
+
+
+class RightBoundary(SubDomain):
+    def inside(self, x, on_boundary):
+        tol = 1E-14
+        if on_boundary and near(x[0], x_right, tol):
+            return True
+        else:
+            return False
+
+
+@patch.dict('sys.modules', **{'precice': tests.MockedPrecice})
+class TestWriteData(TestCase):
+    dummy_config = "tests/precice-adapter-config.json"
+
+    def setUp(self):
+        pass
+
+    def test_write_scalar_data(self):
+        from precice import Interface
+        import fenicsadapter
+        Interface.configure = MagicMock()
+        Interface.write_block_scalar_data = MagicMock()
+        Interface.read_block_scalar_data = MagicMock()
+        Interface.get_dimensions = MagicMock(return_value=2)
+        Interface.set_mesh_vertices = MagicMock()
+        Interface.initialize = MagicMock()
+        Interface.initialize_data = MagicMock()
+        Interface.is_action_required = MagicMock(return_value=False)
+        Interface.fulfilled_action = MagicMock()
+        Interface.advance = MagicMock()
+        Interface.get_mesh_id = MagicMock()
+        Interface.get_data_id = MagicMock(return_value=15)
+        Interface.is_read_data_available = MagicMock(return_value=False)
+
+        expr = Expression("x[0]*x[0] + x[1]*x[1]", degree=2)
+        mesh = UnitSquareMesh(10, 10)
+        V = FunctionSpace(mesh, "P", 2)
+        u = interpolate(expr, V)
+
+        precice = fenicsadapter.Adapter(self.dummy_config)
+        precice._coupling_bc_expression = MagicMock()
+        precice.initialize(RightBoundary(), mesh, u, u, u)
+        precice.advance(u, u, u, 0, 0, 0)
+
+        expected_data_id = 15
+        expected_size = 11
+        expected_values = np.array([x_right**2 + y**2 for y in np.linspace(y_bottom, y_top, 11)])
+        expected_ids = np.zeros(11)
+
+        expected_args = [expected_data_id, expected_size, expected_ids, expected_values]
+
+        for arg, expected_arg in zip(Interface.write_block_scalar_data.call_args[0], expected_args):
+            if type(arg) is int:
+                self.assertTrue(arg == expected_arg)
+            elif type(arg) is np.ndarray:
+                np.testing.assert_allclose(arg, expected_arg)
+
+    def test_write_vector_data(self):
+        from precice import Interface
+        import fenicsadapter
+        Interface.configure = MagicMock()
+        Interface.write_block_vector_data = MagicMock()
+        Interface.read_block_vector_data = MagicMock()
+        Interface.get_dimensions = MagicMock(return_value=2)
+        Interface.set_mesh_vertices = MagicMock()
+        Interface.initialize = MagicMock()
+        Interface.initialize_data = MagicMock()
+        Interface.is_action_required = MagicMock(return_value=False)
+        Interface.fulfilled_action = MagicMock()
+        Interface.advance = MagicMock()
+        Interface.get_mesh_id = MagicMock()
+        Interface.get_data_id = MagicMock(return_value=15)
+        Interface.is_read_data_available = MagicMock(return_value=False)
+
+        expr = Expression(("x[0]*x[0] + x[1]*x[1]", "x[0]*x[0] - x[1]*x[1]"), degree=2)
+        mesh = UnitSquareMesh(10, 10)
+        V = VectorFunctionSpace(mesh, "P", 2)
+        u = interpolate(expr, V)
+
+        precice = fenicsadapter.Adapter(self.dummy_config)
+        precice._coupling_bc_expression = MagicMock()
+        precice.initialize(RightBoundary(), mesh, u, u, u)
+        precice.advance(u, u, u, 0, 0, 0)
+
+        expected_data_id = 15
+        expected_size = 11
+        expected_values_x = np.array([x_right ** 2 + y ** 2 for y in np.linspace(y_bottom, y_top, 11)])
+        expected_values_y = np.array([x_right ** 2 - y ** 2 for y in np.linspace(y_bottom, y_top, 11)])
+        expected_values = np.stack([expected_values_x, expected_values_y]).T.ravel()
+        expected_ids = np.zeros(11)
+
+        expected_args = [expected_data_id, expected_size, expected_ids, expected_values]
+
+        for arg, expected_arg in zip(Interface.write_block_vector_data.call_args[0], expected_args):
+            if type(arg) is int:
+                self.assertTrue(arg == expected_arg)
+            elif type(arg) is np.ndarray:
+                np.testing.assert_almost_equal(arg, expected_arg)


### PR DESCRIPTION
Enable the adapter to be used for FSI with FEniCS as 2D structure solver. 

List of new features:

- Introduce treatment of vector valued data and functions in FEniCS. Displacements and Forces are vector valued functions and have to be treated correspondingly.
- Buffer the RBF interpolation in the CustomExpression class for runtime improvement in FSI simulations
- Use PointSource for quantities that are mapped conservatively and are applied to mesh nodes (used for Forces)
- `read_block_vector_data` and `read_block_scalar_data` are wrapped into `read_block_data` that differentiates between the two cases (scalar/vector) and calls the respective preCICE function 

# Open ToDos

- [x] make the 2D-3D mapping more user friendly (solved by 2c9c2a0)
- [x] find a proper treatment for application of point Forces
- [x] fix automated testing (see https://github.com/precice/fenics-adapter/pull/38#issuecomment-517301221)




