### PR TITLE
Add systemtests triggering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,12 @@ matrix:
       - $PY -m pip install --upgrade pip
       - $PY -m pip install scipy 
       - $PY -m pip install --upgrade setuptools
+  - os: linux
+    name: "Systemtests"
+    if: fork = false AND ( branch = master OR branch = develop )
+    script:
+    - curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
+    - travis_wait 60 python trigger_systemtests.py --adapter fenics --wait
 
   - os: osx
     name: "Mock tests [OSx]"


### PR DESCRIPTION
This adds triggering of  FEniCS-FEniCS system test, that was added here  https://github.com/precice/systemtests/pull/79 and updated to docker-compose here https://github.com/precice/systemtests/pull/86. 