### PR TITLE
Mapping nearestprojection

### DIFF
--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -215,7 +215,7 @@ class GeneralInterpolationExpression(CustomExpression):
 
 
 class ExactInterpolationExpression(CustomExpression):
-    """Uses cubic spline interpolation for implementation of CustomExpression.interpolate. Only allows intepolation on
+    """Uses cubic spline interpolation for implementation of CustomExpression.interpolate. Only allows interpolation on
     coupling that are parallel to the y axis, and if the coordinates in self._coords_y are ordered such that the nodes
     on the coupling mesh are traversed w.r.t their connectivity.
     However, this method allows to exactly recover the solution at the coupling interface, if it is a polynomial of
@@ -408,6 +408,38 @@ class Adapter:
         elif self._dimensions == 3:
             return np.stack([vertices_x, vertices_y, vertices_z]), n
 
+    def _extract_coupling_boundary_edges(self):
+        """Extracts edges of mesh which lie on the boundary.
+        :return: list of vertex pair IDs showing edges
+
+        NOTE: Edge calculation is only relevant in 2D cases.
+        """
+
+        n = 0
+        vertices_1 = []
+        vertices_2 = []
+
+        for v1 in dolfin.vertices(self._mesh_fenics):
+            if self._coupling_subdomain.inside(v1.point, True):
+
+                for v2 in dolfin.vertices(self._mesh_fenics):
+                    if self._coupling_subdomain.inside(v2.point, True):
+
+                        for edge1 in dolfin.edges(v1):
+                            for edge2 in dolfin.edges(v2):
+
+                                if edge1 == edge2:
+                                    n += 1
+                                    vertices_1.append(v1.x(0))
+                                    vertices_1.append(v1.x(1))
+                                    vertices_2.append(v2.x(0))
+                                    vertices_2.append(v2.x(1))
+
+        vertices1_ids = self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, vertices_1)
+        vertices2_ids = self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, vertices_2)
+
+        return vertices1_ids, vertices2_ids
+
     def set_coupling_mesh(self, mesh, subdomain):
         """Sets the coupling mesh. Called by initalize() function at the
         beginning of the simulation.
@@ -417,6 +449,17 @@ class Adapter:
         self._coupling_mesh_vertices, self._n_vertices = self._extract_coupling_boundary_vertices()
         self._vertex_ids = np.zeros(self._n_vertices)
         self._interface.set_mesh_vertices(self._mesh_id, self._n_vertices, self._coupling_mesh_vertices.flatten('F'), self._vertex_ids)
+        edge_vertex_ids1, edge_vertex_ids2 = self._extract_coupling_boundary_edges()
+
+        for i in edge_vertex_ids1:
+            self._interface.set_mesh_edge(self._mesh_id, edge_vertex_ids1[i], edge_vertex_ids2[i])
+
+        """
+        for vert in dolfin.vertices(self._mesh_fenics):
+            print("\nvert", vert.index())
+            for edge in dolfin.edges(vert):
+                print("   edge", edge.index())
+        """
 
     def _set_write_field(self, write_function_init):
         """Sets the write field. Called by initalize() function at the

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -22,7 +22,7 @@ except ImportError:
        raise Exception("ERROR: PRECICE_ROOT not defined!")
 
     precice_root = os.getenv('PRECICE_ROOT')
-    precice_python_adapter_root = precice_root+"/src/precice/bindings/python_future"
+    precice_python_adapter_root = precice_root+"/src/precice/bindings/python"
     sys.path.insert(0, precice_python_adapter_root)
     import precice
 

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -450,8 +450,12 @@ class Adapter:
         vertices_2 = np.array(vertices_2)
         vertices1_ids = np.zeros(n)
         vertices2_ids = np.zeros(n)
+
         self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, n, vertices_1, vertices1_ids)
         self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, n, vertices_2, vertices2_ids)
+
+        for i in range(len(vertices1_ids)):
+            print(vertices1_ids[i], vertices2_ids[i])
 
         return vertices1_ids, vertices2_ids
 
@@ -459,6 +463,7 @@ class Adapter:
         """Sets the coupling mesh. Called by initalize() function at the
         beginning of the simulation.
         """
+
         self._coupling_subdomain = subdomain
         self._mesh_fenics = mesh
         self._coupling_mesh_vertices, self._n_vertices = self._extract_coupling_boundary_vertices()
@@ -467,9 +472,7 @@ class Adapter:
         self._edge_vertex_ids1, self._edge_vertex_ids2 = self._extract_coupling_boundary_edges()
 
         for i in range(len(self._edge_vertex_ids1)):
-            print(self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
             self._interface.set_mesh_edge(self._mesh_id, self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
-
 
     def _set_write_field(self, write_function_init):
         """Sets the write field. Called by initalize() function at the

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -418,7 +418,8 @@ class Adapter:
 
     def _extract_coupling_boundary_edges(self):
         """Extracts edges of mesh which lie on the boundary.
-        :return: list of vertex pair IDs showing edges
+        :return: two arrays of vertex IDs. Array 1 consists of first points of all edges
+        and Array 2 consists of second points of all edges
 
         NOTE: Edge calculation is only relevant in 2D cases.
         """
@@ -453,9 +454,6 @@ class Adapter:
 
         self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, n, vertices_1, vertices1_ids)
         self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, n, vertices_2, vertices2_ids)
-
-        for i in range(len(vertices1_ids)):
-            print(vertices1_ids[i], vertices2_ids[i])
 
         return vertices1_ids, vertices2_ids
 

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -403,6 +403,8 @@ class Adapter:
                 else:
                     raise Exception("Dimensions do not match!")
 
+        assert(n != 0), "No coupling boundary vertices detected"
+
         if self._dimensions == 2:
             return np.stack([vertices_x, vertices_y]), n
         elif self._dimensions == 3:
@@ -461,7 +463,6 @@ class Adapter:
         """Sets the coupling mesh. Called by initalize() function at the
         beginning of the simulation.
         """
-
         self._coupling_subdomain = subdomain
         self._mesh_fenics = mesh
         self._coupling_mesh_vertices, self._n_vertices = self._extract_coupling_boundary_vertices()
@@ -470,6 +471,8 @@ class Adapter:
         self._edge_vertex_ids1, self._edge_vertex_ids2 = self._extract_coupling_boundary_edges()
 
         for i in range(len(self._edge_vertex_ids1)):
+            # print("edge vertex ids1 = {}".format(self._edge_vertex_ids1[i]))
+            # print("edge vertex ids2 = {}".format(self._edge_vertex_ids2[i]))
             self._interface.set_mesh_edge(self._mesh_id, self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
 
     def _set_write_field(self, write_function_init):

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -471,8 +471,6 @@ class Adapter:
         self._edge_vertex_ids1, self._edge_vertex_ids2 = self._extract_coupling_boundary_edges()
 
         for i in range(len(self._edge_vertex_ids1)):
-            # print("edge vertex ids1 = {}".format(self._edge_vertex_ids1[i]))
-            # print("edge vertex ids2 = {}".format(self._edge_vertex_ids2[i]))
             self._interface.set_mesh_edge(self._mesh_id, self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
 
     def _set_write_field(self, write_function_init):

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -22,7 +22,7 @@ except ImportError:
        raise Exception("ERROR: PRECICE_ROOT not defined!")
 
     precice_root = os.getenv('PRECICE_ROOT')
-    precice_python_adapter_root = precice_root+"/src/precice/bindings/python"
+    precice_python_adapter_root = precice_root+"/src/precice/bindings/python_future"
     sys.path.insert(0, precice_python_adapter_root)
     import precice
 
@@ -420,10 +420,10 @@ class Adapter:
         vertices_2 = []
 
         for v1 in dolfin.vertices(self._mesh_fenics):
-            if self._coupling_subdomain.inside(v1.point, True):
+            if self._coupling_subdomain.inside(v1.point(), True):
 
                 for v2 in dolfin.vertices(self._mesh_fenics):
-                    if self._coupling_subdomain.inside(v2.point, True):
+                    if self._coupling_subdomain.inside(v2.point(), True):
 
                         for edge1 in dolfin.edges(v1):
                             for edge2 in dolfin.edges(v2):
@@ -435,8 +435,10 @@ class Adapter:
                                     vertices_2.append(v2.x(0))
                                     vertices_2.append(v2.x(1))
 
-        vertices1_ids = self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, vertices_1)
-        vertices2_ids = self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, vertices_2)
+        vertices1_ids = []
+        vertices2_ids = []
+        self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, n, vertices_1, vertices1_ids)
+        self._interface.get_mesh_vertex_ids_from_positions(self._mesh_id, n, vertices_2, vertices2_ids)
 
         return vertices1_ids, vertices2_ids
 

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -470,6 +470,7 @@ class Adapter:
             print(self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
             self._interface.set_mesh_edge(self._mesh_id, self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
 
+
     def _set_write_field(self, write_function_init):
         """Sets the write field. Called by initalize() function at the
         beginning of the simulation.

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -412,9 +412,10 @@ class Adapter:
         """Returns true if both vertices are connected by an edge. """
         for edge1 in dolfin.edges(v1):
             for edge2 in dolfin.edges(v2):
-                if edge1 == edge2:  # Vertices are connected by edge
+                print(edge1, edge2)
+                if edge1 is edge2:  # Vertices are connected by edge
+                    print("Returning true")
                     return True
-
         return False
 
     def _extract_coupling_boundary_edges(self):
@@ -435,12 +436,17 @@ class Adapter:
         for v1 in vertices.keys():
             for v2 in vertices.keys():
                 if self._are_connected_by_edge(v1, v2):
-                    vertices[v1].append(v2)
-                    vertices[v2].append(v1)
+                    print(v1, v2)
+                    vertices[v1] = v2
+                    vertices[v2] = v1
 
         vertices_1 = []
         vertices_2 = []
 
+        """
+        for v1 in vertices:
+            print(v1, vertices[v1])
+        """
         for v1, v2 in vertices.items():
             vertices_1.append(v1.x(0))
             vertices_1.append(v1.x(1))
@@ -469,13 +475,6 @@ class Adapter:
 
         for i in edge_vertex_ids1:
             self._interface.set_mesh_edge(self._mesh_id, edge_vertex_ids1[i], edge_vertex_ids2[i])
-
-        """
-        for vert in dolfin.vertices(self._mesh_fenics):
-            print("\nvert", vert.index())
-            for edge in dolfin.edges(vert):
-                print("   edge", edge.index())
-        """
 
     def _set_write_field(self, write_function_init):
         """Sets the write field. Called by initalize() function at the

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -412,9 +412,7 @@ class Adapter:
         """Returns true if both vertices are connected by an edge. """
         for edge1 in dolfin.edges(v1):
             for edge2 in dolfin.edges(v2):
-                print(edge1, edge2)
-                if edge1 is edge2:  # Vertices are connected by edge
-                    print("Returning true")
+                if edge1.index() == edge2.index():  # Vertices are connected by edge
                     return True
         return False
 
@@ -436,17 +434,12 @@ class Adapter:
         for v1 in vertices.keys():
             for v2 in vertices.keys():
                 if self._are_connected_by_edge(v1, v2):
-                    print(v1, v2)
                     vertices[v1] = v2
                     vertices[v2] = v1
 
         vertices_1 = []
         vertices_2 = []
 
-        """
-        for v1 in vertices:
-            print(v1, vertices[v1])
-        """
         for v1, v2 in vertices.items():
             vertices_1.append(v1.x(0))
             vertices_1.append(v1.x(1))
@@ -471,10 +464,11 @@ class Adapter:
         self._coupling_mesh_vertices, self._n_vertices = self._extract_coupling_boundary_vertices()
         self._vertex_ids = np.zeros(self._n_vertices)
         self._interface.set_mesh_vertices(self._mesh_id, self._n_vertices, self._coupling_mesh_vertices.flatten('F'), self._vertex_ids)
-        edge_vertex_ids1, edge_vertex_ids2 = self._extract_coupling_boundary_edges()
+        self._edge_vertex_ids1, self._edge_vertex_ids2 = self._extract_coupling_boundary_edges()
 
-        for i in edge_vertex_ids1:
-            self._interface.set_mesh_edge(self._mesh_id, edge_vertex_ids1[i], edge_vertex_ids2[i])
+        for i in range(len(self._edge_vertex_ids1)):
+            print(self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
+            self._interface.set_mesh_edge(self._mesh_id, self._edge_vertex_ids1[i], self._edge_vertex_ids2[i])
 
     def _set_write_field(self, write_function_init):
         """Sets the write field. Called by initalize() function at the

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -52,6 +52,7 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
         Interface.get_mesh_vertex_ids_from_positions = MagicMock()
+        Interface.set_mesh_edge = MagicMock()
 
         write_u = self.scalar_function
         read_u = self.vector_function
@@ -92,6 +93,7 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
         Interface.get_mesh_vertex_ids_from_positions = MagicMock()
+        Interface.set_mesh_edge = MagicMock()
 
         write_u = self.vector_function
         read_u = self.scalar_function
@@ -139,6 +141,7 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
         Interface.get_mesh_vertex_ids_from_positions = MagicMock()
+        Interface.set_mesh_edge = MagicMock()
 
         write_u = self.vector_function
         read_u = self.scalar_function
@@ -184,6 +187,7 @@ class TestWriteData(TestCase):
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
         Interface.get_mesh_vertex_ids_from_positions = MagicMock()
+        Interface.set_mesh_edge = MagicMock()
 
         write_u = self.scalar_function
         read_u = self.vector_function

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -51,6 +51,7 @@ class TestWriteData(TestCase):
         Interface.get_mesh_id = MagicMock()
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
+        Interface.get_mesh_vertex_ids_from_positions = MagicMock()
 
         write_u = self.scalar_function
         read_u = self.vector_function
@@ -90,6 +91,7 @@ class TestWriteData(TestCase):
         Interface.get_mesh_id = MagicMock()
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
+        Interface.get_mesh_vertex_ids_from_positions = MagicMock()
 
         write_u = self.vector_function
         read_u = self.scalar_function
@@ -136,6 +138,7 @@ class TestWriteData(TestCase):
         Interface.get_mesh_id = MagicMock()
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
+        Interface.get_mesh_vertex_ids_from_positions = MagicMock()
 
         write_u = self.vector_function
         read_u = self.scalar_function
@@ -180,6 +183,7 @@ class TestWriteData(TestCase):
         Interface.get_mesh_id = MagicMock()
         Interface.get_data_id = MagicMock(return_value=15)
         Interface.is_read_data_available = MagicMock(return_value=False)
+        Interface.get_mesh_vertex_ids_from_positions = MagicMock()
 
         write_u = self.scalar_function
         read_u = self.vector_function


### PR DESCRIPTION
Adding interface mesh edge definitions necessary to enable `nearest-projection` mapping in preCICE. This added functionality is tested using [this tutorial case](https://github.com/precice/tutorials/tree/master/HT/partitioned-heat/fenics-fenics). From the working of `nearest-neighbor` and `nearest-projection` we understand that `nearest-projection` will estimate the exact solution of the 2D Poissons equation if the problem setup is devised in a way that the analytical solution is linear in the direction of flux of the Neumann boundary condition. More on this formulation can be found in [this document](https://fenicsproject.org/pub/tutorial/pdf/fenics-tutorial-vol1.pdf) on page no. 16 Section 2.1.3
The results of this tutorial problem are shown below:
![nn_linearsoln](https://user-images.githubusercontent.com/44898158/64692465-cd96f380-d4b2-11e9-9ff5-282221a1b099.png)
![np_linearsoln](https://user-images.githubusercontent.com/44898158/64692482-d7205b80-d4b2-11e9-8be9-bfe93a69614c.png)
