### PR TITLE
Fix checkpointing and solverstate copy for tuples

### DIFF
--- a/fenicsadapter/checkpointing.py
+++ b/fenicsadapter/checkpointing.py
@@ -19,9 +19,9 @@ class Checkpoint:
         :param n: timestep
         """
         if self.is_empty():
-            self._state = SolverState(None, None, None)
-
-        self._state.copy(new_state)
+            self._state = new_state.get_copy()
+        else:
+            self._state.copy(new_state)
 
     def is_empty(self):
         """

--- a/fenicsadapter/solverstate.py
+++ b/fenicsadapter/solverstate.py
@@ -1,3 +1,10 @@
+def check_type_consistency(other_u, my_u):
+    try:
+        assert(type(other_u) == type(my_u))
+    except AssertionError as e:
+        raise Exception("{}: other_u = {}; my_u = {}".format(e, other_u, my_u))
+
+
 class SolverState:
     def __init__(self, u, t, n):
         """
@@ -9,6 +16,9 @@ class SolverState:
         self.u = u
         self.t = t
         self.n = n
+
+    def _is_initialized(self):
+        return (self.u is not None) and (self.t is not None) and (self.n is not None)
 
     def get_state(self):
         """
@@ -23,6 +33,9 @@ class SolverState:
         This may also have an effect outside of this object! Compare to SolverState.copy(other_state).
         :param other_state:
         """
+        assert(self._is_initialized())
+        check_type_consistency(other_state.u, self.u)
+
         if type(other_state.u) is tuple:
             for elem, other_elem in zip(self.u, other_state.u):
                 elem.assign(other_elem)
@@ -32,19 +45,30 @@ class SolverState:
         self.t = other_state.t
         self.n = other_state.n
 
+    def get_copy(self):
+        if type(self.u) is tuple:
+            copied_u = tuple((elem.copy() for elem in self.u))
+        else:
+            copied_u = self.u.copy()
+
+        copied_t = self.t
+        copied_n = self.n
+
+        return SolverState(copied_u, copied_t, copied_n)
+
     def copy(self, other_state):
         """
         copies a state using FEniCS copy function. self.u is overwritten.
         This does not have an effect outside of this object! Compare to SolverState.update(other_state).
         :param other_state:
         """
-        if type(other_state.u) is tuple:
-            self.u = (other_elem.copy() for other_elem in other_state.u)
-        else:
-            self.u = other_state.u.copy()
+        assert(self._is_initialized())
+        check_type_consistency(other_state.u, self.u)
 
-        self.t = other_state.t
-        self.n = other_state.n
+        copied_state = other_state.get_copy()
+        self.u = copied_state.u
+        self.t = copied_state.t
+        self.n = copied_state.n
 
     def print_state(self):
         u, t, n = self.get_state()


### PR DESCRIPTION
* introduce explicit `get_copy()`
* discard initialization of `SolverState` with `None` in `checkpointing.py`