### PR TITLE
Refactoring adapter to use new python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,6 @@ matrix:
       - pip3 install scipy
 
 script: 
-  - mkdir -p precice && echo -e "from setuptools import setup\nsetup(name='precice')" > precice/setup.py
-  - $PY -m pip install ./precice/
+  - mkdir -p precice_future && echo -e "from setuptools import setup\nsetup(name='precice_future')" > precice_future/setup.py
+  - $PY -m pip install ./precice_future/
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then  $PY setup.py test ; else $PY setup.py test -s tests.test_fenicsadapter ; fi

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -469,7 +469,6 @@ class Adapter:
         self._coupling_subdomain = subdomain
         self._mesh_fenics = mesh
         self._coupling_mesh_vertices, self._n_vertices = self._extract_coupling_boundary_vertices()
-        self._vertex_ids = np.zeros(self._n_vertices)
         self._vertex_ids = self._interface.set_mesh_vertices(self._mesh_id, self._coupling_mesh_vertices.flatten('F'))
         self._edge_vertex_ids1, self._edge_vertex_ids2 = self._extract_coupling_boundary_edges()
 

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -361,22 +361,19 @@ class Adapter:
         assert(self._read_function_type in list(FunctionType))
         
         if self._read_function_type is FunctionType.SCALAR:
-            self._interface.read_block_scalar_data(self._read_data_id, self._vertex_ids, self._read_data)
+            self._read_data = self._interface.read_block_scalar_data(self._read_data_id, self._vertex_ids)
         
         elif self._read_function_type is FunctionType.VECTOR:
             if self._fenics_dimensions == self._dimensions:
-                self._interface.read_block_vector_data(self._read_data_id, self._vertex_ids, self._read_data.ravel())
+                self._read_data = self._interface.read_block_vector_data(self._read_data_id, self._vertex_ids)
                                
             elif self._can_apply_2d_3d_coupling():
-                precice_data = np.zeros(self._n_vertices * self._dimensions)
-                self._interface.read_block_vector_data(self._read_data_id, self._vertex_ids, precice_data)
-                
-                precice_read_data = np.reshape(precice_data,(self._n_vertices, self._dimensions), 'C')
+                precice_read_data = self._interface.read_block_vector_data(self._read_data_id, self._vertex_ids)
                 
                 self._read_data[:, 0] = precice_read_data[:, 0]
                 self._read_data[:, 1] = precice_read_data[:, 1]
                 #z is the dead direction so it is supposed that the data is close to zero
-                np.testing.assert_allclose(precice_read_data[:, 2], np.zeros_like(precice_read_data[:, 2]), )
+                np.testing.assert_allclose(precice_read_data[:, 2], np.zeros_like(precice_read_data[:, 2]))
                 assert(np.sum(np.abs(precice_read_data[:,2]))< 1e-10)
             else: 
                 raise Exception("Dimensions don't match.")

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(name='fenics-adapter',
       author_email='benjamin.rueth@tum.de',
       license='LGPL-3.0',
       packages=['fenicsadapter'],
-      install_requires=['precice', 'fenics', 'scipy', 'numpy>=1.13.3'],
+      install_requires=['precice_future', 'fenics', 'scipy', 'numpy>=1.13.3'],
       test_suite='tests',
       zip_safe=False)

--- a/tests/test_fenicsadapter.py
+++ b/tests/test_fenicsadapter.py
@@ -27,7 +27,7 @@ class MockedArray:
         return 0
 
 
-@patch.dict('sys.modules', **{'dolfin': fake_dolfin, 'precice': tests.MockedPrecice})
+@patch.dict('sys.modules', **{'dolfin': fake_dolfin, 'precice_future': tests.MockedPrecice})
 class TestCheckpointing(TestCase):
     """
     Test suite to check whether checkpointing is done correctly, if the advance function is called. We use the mock
@@ -76,7 +76,7 @@ class TestCheckpointing(TestCase):
         Test correct checkpointing, if advance succeeded
         """
         import fenicsadapter
-        from precice import Interface, action_read_iteration_checkpoint, \
+        from precice_future import Interface, action_read_iteration_checkpoint, \
             action_write_iteration_checkpoint
 
         def is_action_required_behavior(py_action):
@@ -117,7 +117,7 @@ class TestCheckpointing(TestCase):
         Test correct checkpointing, if advance did not succeed and we have to rollback
         """
         import fenicsadapter
-        from precice import Interface, action_write_iteration_checkpoint, \
+        from precice_future import Interface, action_write_iteration_checkpoint, \
             action_read_iteration_checkpoint
 
         def is_action_required_behavior(py_action):
@@ -157,7 +157,7 @@ class TestCheckpointing(TestCase):
         :param fake_PySolverInterface_PySolverInterface: mock instance of PySolverInterface.PySolverInterface
         """
         import fenicsadapter
-        from precice import Interface, action_read_iteration_checkpoint, \
+        from precice_future import Interface, action_read_iteration_checkpoint, \
             action_write_iteration_checkpoint
 
         def is_action_required_behavior(py_action):
@@ -192,7 +192,7 @@ class TestCheckpointing(TestCase):
         self.assertEqual(precice._u_cp.value, self.u_cp_mocked.value)
 
 
-@patch.dict('sys.modules', **{'dolfin': fake_dolfin, 'precice': tests.MockedPrecice})
+@patch.dict('sys.modules', **{'dolfin': fake_dolfin, 'precice_future': tests.MockedPrecice})
 class TestIsCouplingOngoing(TestCase):
 
     dummy_config = "tests/precice-adapter-config.json"
@@ -202,7 +202,7 @@ class TestIsCouplingOngoing(TestCase):
 
     def test_isCouplingOngoing(self):
         import fenicsadapter
-        from precice import Interface
+        from precice_future import Interface
         Interface.is_coupling_ongoing = MagicMock(return_value=True)
         Interface.configure = MagicMock()
         Interface.get_dimensions = MagicMock()

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -64,11 +64,10 @@ class TestWriteData(TestCase):
         precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
-        expected_size = 11
         expected_values = np.array([self.scalar_expr(x_right, y) for y in np.linspace(y_bottom, y_top, 11)])
         expected_ids = np.zeros(11)
 
-        expected_args = [expected_data_id, expected_size, expected_ids, expected_values]
+        expected_args = [expected_data_id, expected_ids, expected_values]
 
         for arg, expected_arg in zip(Interface.write_block_scalar_data.call_args[0], expected_args):
             if type(arg) is int:
@@ -105,13 +104,12 @@ class TestWriteData(TestCase):
         precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
-        expected_size = 11
         expected_values_x = np.array([self.vector_expr(x_right, y)[0] for y in np.linspace(y_bottom, y_top, 11)])
         expected_values_y = np.array([self.vector_expr(x_right, y)[1] for y in np.linspace(y_bottom, y_top, 11)])
         expected_values = np.stack([expected_values_x, expected_values_y]).T.ravel()
         expected_ids = np.zeros(11)
 
-        expected_args = [expected_data_id, expected_size, expected_ids, expected_values]
+        expected_args = [expected_data_id, expected_ids, expected_values]
 
         for arg, expected_arg in zip(Interface.write_block_vector_data.call_args[0], expected_args):
             if type(arg) is int:
@@ -153,11 +151,10 @@ class TestWriteData(TestCase):
         precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
-        expected_size = 11
         expected_values = np.array([i for i in range(11)])
         expected_ids = np.zeros(11)
 
-        expected_args = [expected_data_id, expected_size, expected_ids, expected_values]
+        expected_args = [expected_data_id, expected_ids, expected_values]
 
         for arg, expected_arg in zip(Interface.read_block_scalar_data.call_args[0], expected_args):
             if type(arg) is int:
@@ -199,11 +196,10 @@ class TestWriteData(TestCase):
         precice.advance(write_u, u_init, u_init, 0, 0, 0)
 
         expected_data_id = 15
-        expected_size = 11
         expected_values = np.array([i for i in range(2 * 11)])
         expected_ids = np.zeros(11)
 
-        expected_args = [expected_data_id, expected_size, expected_ids, expected_values]
+        expected_args = [expected_data_id, expected_ids, expected_values]
 
         for arg, expected_arg in zip(Interface.read_block_vector_data.call_args[0], expected_args):
             if type(arg) is int:


### PR DESCRIPTION
This PR refactors the adapter to use the [new python bindings](https://github.com/precice/precice/tree/develop/src/precice/bindings/python_future). This PR is intended to be merge consecutively with https://github.com/precice/precice/pull/547 to ensure that error handling for all entities is done only once, either in the adapter or in the bindings. 