### PR TITLE
Removes interpolation_type option and RBFInterpolationExpression

### DIFF
--- a/fenicsadapter/config.py
+++ b/fenicsadapter/config.py
@@ -46,10 +46,6 @@ class Config:
         except:
             self._write_data_name = None
         self._read_data_name = data["interface"]["read_data_name"]
-        try:
-            self._interpolation_type = data["interface"]["interpolation_type"]
-        except:
-            self._interpolation_type = None
 
         read_file.close()
 

--- a/fenicsadapter/expression_core.py
+++ b/fenicsadapter/expression_core.py
@@ -157,67 +157,6 @@ class CouplingExpression(UserExpression):
             return self._function_type is FunctionType.VECTOR
 
 
-class RBFInterpolationExpression(CouplingExpression):
-    """
-    Uses RBF interpolation for implementation of CustomExpression.interpolate. Allows for arbitrary coupling
-    interfaces, but has limited accuracy.
-    """
-
-    def create_interpolant(self):
-        """
-        See base class description.
-        """
-        interpolant = []
-        if self._dimension == 1:
-            assert (
-                self.is_scalar_valued())  # for 1D only R->R mapping is allowed by preCICE, no need to implement Vector case
-            interpolant.append(Rbf(self._coords_x, self._vals))
-        elif self._dimension == 2:
-            if self.is_scalar_valued():  # check if scalar or vector-valued
-                interpolant.append(Rbf(self._coords_x, self._coords_y, self._vals))
-            elif self.is_vector_valued():
-                interpolant.append(Rbf(self._coords_x, self._coords_y,
-                                       self._vals[:, 0]))  # extract dim_no element of each vector
-                interpolant.append(Rbf(self._coords_x, self._coords_y,
-                                       self._vals[:, 1]))  # extract dim_no element of each vector
-            else:
-                raise Exception("Problem dimension and data dimension not matching.")
-        elif self._dimension == 3:
-            logger.warning("RBF Interpolation for 3D Simulations has not been properly tested!")
-            if self.is_scalar_valued():
-                interpolant.append(Rbf(self._coords_x, self._coords_y, self._coords_z, self._vals))
-            elif self.is_vector_valued():
-                interpolant.append(Rbf(self._coords_x, self._coords_y, self._coords_z, self._vals[:, 0]))
-                interpolant.append(Rbf(self._coords_x, self._coords_y, self._coords_z, self._vals[:, 1]))
-                interpolant.append(Rbf(self._coords_x, self._coords_y, self._coords_z, self._vals[:, 2]))
-            else:
-                raise Exception("Problem dimension and data dimension not matching.")
-        else:
-            raise Exception("Dimension of the function invalid/not supported.")
-
-        return interpolant
-
-    def interpolate(self, x):
-        """
-        See base class description.
-        """
-        assert ((self.is_scalar_valued() and self._vals.ndim == 1) or
-                (self.is_vector_valued() and self._vals.ndim == self._dimension))
-
-        return_value = self._vals.ndim * [None]
-
-        if self._dimension == 1:
-            for i in range(self._vals.ndim):
-                return_value[i] = self._f[i](x[0])
-        if self._dimension == 2:
-            for i in range(self._vals.ndim):
-                return_value[i] = self._f[i](x[0], x[1])
-        if self._dimension == 3:
-            for i in range(self._vals.ndim):
-                return_value[i] = self._f[i](x[0], x[1], x[2])
-        return return_value
-
-
 class SegregatedRBFInterpolationExpression(CouplingExpression):
     """
     Uses polynomial quadratic fit + RBF interpolation for implementation of CustomExpression.interpolate. Allows for

--- a/fenicsadapter/fenicsadapter.py
+++ b/fenicsadapter/fenicsadapter.py
@@ -7,7 +7,7 @@ import logging
 import precice
 from .adapter_core import FunctionType, determine_function_type, convert_fenics_to_precice, \
     get_coupling_boundary_vertices, get_coupling_boundary_edges, get_forces_as_point_sources
-from .expression_core import RBFInterpolationExpression, SegregatedRBFInterpolationExpression
+from .expression_core import SegregatedRBFInterpolationExpression
 from .solverstate import SolverState
 from warnings import warn
 
@@ -56,18 +56,8 @@ class Adapter:
         # read data related quantities (read data is read by use to FEniCS from preCICE)
         self._read_function_type = None  # stores whether read function is scalar or vector valued
 
-        # Interpolation strategy as provided by the user
-        if self._config.get_interpolation_expression_type() == "cubic_spline":
-            raise Exception("cubic_spline has been removed in https://github.com/precice/fenics-adapter/pull/83. "
-                            "Please use rbf_segregated.")
-        elif self._config.get_interpolation_expression_type() == "rbf":
-            self._my_expression = RBFInterpolationExpression
-            print("Using RBF interpolation")
-        elif self._config.get_interpolation_expression_type() == "rbf_segregated":
-            self._my_expression = SegregatedRBFInterpolationExpression
-            print("Using segregated RBF interpolation")
-        else:
-            warn("No valid interpolation strategy entered. It is assumed that the user does not wish to use FEniCS Expressions on the coupling boundary.")
+        # Interpolation strategy
+        self._my_expression = SegregatedRBFInterpolationExpression
 
         # Solver state used by the Adapter internally to handle checkpointing
         self._checkpoint = None


### PR DESCRIPTION
`SegregatedRBFInterpolationExpression` introduced in #83 can be used for all known use-cases of the adapter. This allows us to 

1. remove all other CouplingExpressions,
2. hard code the `Adapter._my_expression` and
3. remove the option `interpolation_type` from the configuration.

This simplifies the configuration and the code. Note that we still keep the object-oriented design, where `CouplingExpression` may be used as a basis for new coupling expressions.