### PR TITLE
Overhaul Initialization

### DIFF
--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -28,7 +28,7 @@ class CouplingMode(Enum):
     Options are: Bi-directional coupling, Uni-directional Write Coupling, Uni-directional Read Coupling
     Used in assertions to check which type of coupling is done
     """
-    BIDIR_COUPLING = 4
+    BIDIR = 4
     UNIDIR_WRITE = 5
     UNIDIR_READ = 6
 

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -22,6 +22,17 @@ class FunctionType(Enum):
     VECTOR = 1  # vector valued function
 
 
+class CouplingMode(Enum):
+    """
+    Defines the type of coupling being used.
+    Options are: Bi-directional coupling, Uni-directional Write Coupling, Uni-directional Read Coupling
+    Used in assertions to check which type of coupling is done
+    """
+    BIDIR_COUPLING = 4
+    UNIDIR_WRITE = 5
+    UNIDIR_READ = 6
+
+
 def determine_function_type(input_obj):
     """
     Determines if the function is scalar- or vector-valued based on rank evaluation.

--- a/fenicsprecice/config.py
+++ b/fenicsprecice/config.py
@@ -40,11 +40,16 @@ class Config:
         self._config_file_name = os.path.join(folder, data["config_file_name"])
         self._participant_name = data["participant_name"]
         self._coupling_mesh_name = data["interface"]["coupling_mesh_name"]
+
         try:
             self._write_data_name = data["interface"]["write_data_name"]
         except:
-            self._write_data_name = None
-        self._read_data_name = data["interface"]["read_data_name"]
+            self._write_data_name = None  # not required for one-way coupling, if this participant reads data
+
+        try:
+            self._read_data_name = data["interface"]["read_data_name"]
+        except:
+            self._read_data_name = None  # not required for one-way coupling, if this participant writes data
 
         read_file.close()
 

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -263,19 +263,21 @@ class Adapter:
 
     def initialize(self, coupling_subdomain, read_function_space=None, write_object=None, fixed_boundary=None):
         """
-        Initializes the coupling interface and sets up the mesh in preCICE. Custom initialization also possible.
+        Initializes the coupling interface and sets up the mesh in preCICE.
 
         Parameters
         ----------
         coupling_subdomain : Object of class dolfin.cpp.mesh.SubDomain
             SubDomain of mesh which is the physical coupling boundary.
         read_function_space : Object of class dolfin.functions.functionspace.FunctionSpace
-            Function space on which the read function lives.
+            Function space on which the read function lives. If not provided then the adapter assumes that this
+            participant is a write-only participant.
         write_object : Object of class dolfin.functions.functionspace.FunctionSpace OR dolfin.functions.function.Function
             Function space on which the write function lives or FEniCS function related to the quantity to be written
-            by FEniCS during each coupling iteration.
+            by FEniCS during each coupling iteration. If not provided then the adapter assumes that this participant is
+            a read-only participant.
         fixed_boundary : Object of class dolfin.fem.bcs.AutoSubDomain
-            SubDomain consisting of a fixed boundary condition. For example in FSI cases usually the solid body
+            SubDomain consisting of a fixed boundary of the mesh. For example in FSI cases usually the solid body
             is fixed at one end (fixed end of a flexible beam).
 
         Returns

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -310,7 +310,8 @@ class Adapter:
         _, self._fenics_dimensions = coords.shape
 
         # Ensure that function spaces of read and write functions use the same mesh
-        assert self._read_function_space.mesh() is self._write_function_space.mesh()
+        if self._coupling_type is CouplingMode.BIDIR_COUPLING:
+            assert self._read_function_space.mesh() is self._write_function_space.mesh()
 
         if fixed_boundary:
             self._Dirichlet_Boundary = fixed_boundary

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -301,6 +301,13 @@ class Adapter:
             raise Exception("Given write object is neither of type dolfin.functions.function.Function or "
                             "dolfin.functions.functionspace.FunctionSpace")
 
+        if type(read_function_space) is FunctionSpace:
+            pass
+        elif read_function_space is None:
+            pass
+        else:
+            raise Exception("Given read_function_space is not of type dolfin.functions.functionspace.FunctionSpace")
+
         if read_function_space is None and write_function_space:
             self._coupling_type = CouplingMode.UNIDIR_WRITE
             assert (self._config.get_write_data_name())

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -301,7 +301,6 @@ class Adapter:
             raise Exception("Given write object is neither of type dolfin.functions.function.Function or "
                             "dolfin.functions.functionspace.FunctionSpace")
 
-        mesh = None
         if read_function_space is None and write_function_space:
             self._coupling_type = CouplingMode.UNIDIR_WRITE
             assert (self._config.get_write_data_name())

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -285,12 +285,15 @@ class Adapter:
             Recommended time step value from preCICE.
         """
 
+        write_function_space, write_function = None, None
         if type(write_object) is Function:
             write_function_space = write_object.function_space()
             write_function = write_object
         elif type(write_object) is FunctionSpace:
             write_function_space = write_object
             write_function = None
+        elif write_object is None:
+            print("Participant {} is read-only participant".format(self._config.get_participant_name()))
         else:
             raise Exception("Given write object is neither of type dolfin.functions.function.Function or "
                             "dolfin.functions.functionspace.FunctionSpace")
@@ -298,6 +301,7 @@ class Adapter:
         if read_function_space is None and write_function_space:
             self._coupling_type = CouplingMode.UNIDIR_WRITE
             assert(self._config.get_write_data_name())
+            print("Participant {} is write-only participant".format(self._config.get_participant_name()))
         elif read_function_space and write_function_space is None:
             self._coupling_type = CouplingMode.UNIDIR_READ
             assert(self._config.get_read_data_name())
@@ -305,8 +309,8 @@ class Adapter:
             self._coupling_type = CouplingMode.BIDIR
             assert(self._config.get_read_data_name() and self._config.get_write_data_name())
         else:
-            raise Exception("Incorrect read and write function space combination provided. Please check input parameters"
-                            "in initialization")
+            raise Exception("Incorrect read and write function space combination provided. Please check input "
+                            "parameters in initialization")
 
         if self._coupling_type is CouplingMode.UNIDIR_READ or self._coupling_type is CouplingMode.BIDIR:
             self._read_function_type = determine_function_type(read_function_space)

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -306,15 +306,18 @@ class Adapter:
             assert (self._config.get_write_data_name())
             print("Participant {} is write-only participant".format(self._config.get_participant_name()))
             mesh = write_function_space.mesh()
+            function_space = write_function_space
         elif read_function_space and write_function_space is None:
             self._coupling_type = CouplingMode.UNIDIR_READ
             assert (self._config.get_read_data_name())
             print("Participant {} is read-only participant".format(self._config.get_participant_name()))
             mesh = read_function_space.mesh()
+            function_space = read_function_space
         elif read_function_space and write_function_space:
             self._coupling_type = CouplingMode.BIDIR
             assert (self._config.get_read_data_name() and self._config.get_write_data_name())
             mesh = read_function_space.mesh()
+            function_space = read_function_space
         elif read_function_space is None and write_function_space is None:
             raise Exception("Neither read_function_space nor write_function_space is provided. Please provide a write "
                             "function_space if one-way coupling with this participant only writing data is intended. "
@@ -333,7 +336,7 @@ class Adapter:
             # Ensure that function spaces of read and write functions are defined using the same mesh
             self._write_function_type = determine_function_type(write_function_space)
 
-        coords = self._read_function_space.tabulate_dof_coordinates()
+        coords = function_space.tabulate_dof_coordinates()
         _, self._fenics_dimensions = coords.shape
 
         # Ensure that function spaces of read and write functions use the same mesh

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -177,7 +177,7 @@ class Adapter:
             The coupling data. A dictionary containing nodal data with vertex coordinates as key and associated data as
             value.
         """
-        assert(self._coupling_type is CouplingMode.UNIDIR_READ or CouplingMode.BIDIR_COUPLING)
+        assert(self._coupling_type is CouplingMode.UNIDIR_READ or CouplingMode.BIDIR)
 
         read_data_id = self._interface.get_data_id(self._config.get_read_data_name(),
                                                    self._interface.get_mesh_id(self._config.get_coupling_mesh_name()))
@@ -230,7 +230,7 @@ class Adapter:
             A FEniCS function consisting of the data which this participant will write to preCICE in every time step.
         """
 
-        assert(self._coupling_type is CouplingMode.UNIDIR_WRITE or CouplingMode.BIDIR_COUPLING)
+        assert(self._coupling_type is CouplingMode.UNIDIR_WRITE or CouplingMode.BIDIR)
 
         w_func = write_function.copy()
         # making sure that the FEniCS function provided by the user is not directly accessed by the Adapter
@@ -286,23 +286,24 @@ class Adapter:
             Recommended time step value from preCICE.
         """
 
-        if read_function_space is None and write_function_space is not None:
+        if read_function_space is None and write_function_space:
             self._coupling_type = CouplingMode.UNIDIR_WRITE
             assert(self._config.get_write_data_name())
-        elif read_function_space is not None and write_function_space is None:
+        elif read_function_space and write_function_space is None:
             self._coupling_type = CouplingMode.UNIDIR_READ
             assert(self._config.get_read_data_name())
-        elif read_function_space is not None and write_function_space is not None:
-            self._coupling_type = CouplingMode.BIDIR_COUPLING
+        elif read_function_space and write_function_space:
+            self._coupling_type = CouplingMode.BIDIR
             assert(self._config.get_read_data_name() and self._config.get_write_data_name())
         else:
             raise Exception("Incorrect read and write function space combination provided. Please check input parameters"
                             "in initialization")
 
-        if self._coupling_type is CouplingMode.UNIDIR_READ or CouplingMode.BIDIR_COUPLING:
+        if self._coupling_type is CouplingMode.UNIDIR_READ or self._coupling_type is CouplingMode.BIDIR:
             self._read_function_type = determine_function_type(read_function_space)
             self._read_function_space = read_function_space
-        elif self._coupling_type is CouplingMode.UNIDIR_WRITE or CouplingMode.BIDIR_COUPLING:
+
+        if self._coupling_type is CouplingMode.UNIDIR_WRITE or self._coupling_type is CouplingMode.BIDIR:
             self._write_function_type = determine_function_type(write_function_space)
             self._write_function_space = write_function_space
 
@@ -310,8 +311,8 @@ class Adapter:
         _, self._fenics_dimensions = coords.shape
 
         # Ensure that function spaces of read and write functions use the same mesh
-        if self._coupling_type is CouplingMode.BIDIR_COUPLING:
-            assert self._read_function_space.mesh() is self._write_function_space.mesh()
+        if self._coupling_type is CouplingMode.BIDIR:
+            assert(self._read_function_space.mesh() is self._write_function_space.mesh())
 
         if fixed_boundary:
             self._Dirichlet_Boundary = fixed_boundary

--- a/tests/test_fenicsprecice.py
+++ b/tests/test_fenicsprecice.py
@@ -135,15 +135,19 @@ class TestExpressionHandling(TestCase):
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock(return_value=self.vertex_ids)
         Interface.get_mesh_id = MagicMock()
+        Interface.get_data_id = MagicMock()
         Interface.set_mesh_edge = MagicMock()
         Interface.initialize = MagicMock()
         Interface.initialize_data = MagicMock()
+        Interface.is_action_required = MagicMock()
+        Interface.mark_action_fulfilled = MagicMock()
+        Interface.write_block_scalar_data = MagicMock()
 
         right_boundary = self.Right()
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.scalar_V, self.scalar_V)
+        precice.initialize(right_boundary, self.scalar_V, self.scalar_V, self.scalar_function)
         values = np.array([self.scalar_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 
@@ -166,15 +170,19 @@ class TestExpressionHandling(TestCase):
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock(return_value=self.vertex_ids)
         Interface.get_mesh_id = MagicMock()
+        Interface.get_data_id = MagicMock()
         Interface.set_mesh_edge = MagicMock()
         Interface.initialize = MagicMock()
         Interface.initialize_data = MagicMock()
+        Interface.is_action_required = MagicMock()
+        Interface.mark_action_fulfilled = MagicMock()
+        Interface.write_block_vector_data = MagicMock()
 
         right_boundary = self.Right()
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.vector_V, self.vector_V)
+        precice.initialize(right_boundary, self.vector_V, self.vector_V, self.vector_function)
         values = np.array([self.vector_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 

--- a/tests/test_fenicsprecice.py
+++ b/tests/test_fenicsprecice.py
@@ -143,7 +143,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.mesh, self.scalar_V)
+        precice.initialize(right_boundary, self.scalar_V)
         values = np.array([self.scalar_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 
@@ -174,7 +174,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.mesh, self.vector_V)
+        precice.initialize(right_boundary, self.vector_V)
         values = np.array([self.vector_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 

--- a/tests/test_fenicsprecice.py
+++ b/tests/test_fenicsprecice.py
@@ -147,7 +147,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.scalar_V, self.scalar_V, self.scalar_function)
+        precice.initialize(right_boundary, self.scalar_V, self.scalar_function)
         values = np.array([self.scalar_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 
@@ -182,7 +182,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.vector_V, self.vector_V, self.vector_function)
+        precice.initialize(right_boundary, self.vector_V, self.vector_function)
         values = np.array([self.vector_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 

--- a/tests/test_fenicsprecice.py
+++ b/tests/test_fenicsprecice.py
@@ -143,7 +143,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.scalar_V)
+        precice.initialize(right_boundary, self.scalar_V, self.scalar_V)
         values = np.array([self.scalar_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 
@@ -174,7 +174,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.vector_V)
+        precice.initialize(right_boundary, self.vector_V, self.vector_V)
         values = np.array([self.vector_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 


### PR DESCRIPTION
This PR overhauls the initialization to make it more versatile. The new initialization function can be used to initialize uni-directional coupling cases. The proposed initialization also addresses: https://github.com/precice/fenics-adapter/issues/89 and makes the adapter initialization more robust.
Closes https://github.com/precice/fenics-adapter/issues/89
To-Do before merging this:
- [x] Update tutorial cases to handle the new signature of `initialize()` (https://github.com/precice/tutorials/pull/119)
- [x] Update mock tests