### PR TITLE
Remove pseudo 2D-3D coupling

### DIFF
--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -157,19 +157,13 @@ def get_coupling_boundary_vertices(mesh_fenics, coupling_subdomain, fenics_dimen
             vertices_x.append(v.x(0))
             if dimensions == 2:
                 vertices_y.append(v.x(1))
-            elif fenics_dimensions == 2 and dimensions == 3:
-                vertices_y.append(v.x(1))
-                vertices_z.append(0)
             else:
                 raise Exception("Dimensions of coupling problem (dim={}) and FEniCS setup (dim={}) do not match!"
                                 .format(dimensions, fenics_dimensions))
 
     assert (n != 0), "No coupling boundary vertices detected"
 
-    if dimensions == 2:
-        return fenics_vertices, np.stack([vertices_x, vertices_y], axis=1)
-    elif dimensions == 3:
-        return fenics_vertices, np.stack([vertices_x, vertices_y, vertices_z], axis=1)
+    return fenics_vertices, np.stack([vertices_x, vertices_y], axis=1)
 
 
 def are_connected_by_edge(v1, v2):
@@ -241,7 +235,7 @@ def get_coupling_boundary_edges(mesh_fenics, coupling_subdomain, id_mapping):
     return vertices1_ids, vertices2_ids
 
 
-def get_forces_as_point_sources(fixed_boundary, function_space, coupling_mesh_vertices, data, z_dead=False):
+def get_forces_as_point_sources(fixed_boundary, function_space, coupling_mesh_vertices, data):
     """
     Creating two dicts of PointSources that can be applied to the assembled system. Appling filter_point_source to
     avoid forces being applied to already existing Dirichlet BC, since this would lead to an overdetermined system
@@ -259,8 +253,6 @@ def get_forces_as_point_sources(fixed_boundary, function_space, coupling_mesh_ve
         numpy array [N x D] where N = number of vertices and D = dimensions of geometry
     data : PointSource
         FEniCS PointSource data carrying forces
-    z_dead: bool
-        Allows to ignore z dimension
 
     Returns
     -------
@@ -278,12 +270,6 @@ def get_forces_as_point_sources(fixed_boundary, function_space, coupling_mesh_ve
 
     # Check for shape of coupling_mesh_vertices and raise Assertion for 3D
     n_vertices, dims = coupling_mesh_vertices.shape
-
-    if z_dead:
-        assert (dims == 3), "z_dead=True is only allowed for 3D data"
-    else:
-        assert (dims == 2), "This Adapter can create Point Sources only from 2D data. Use z_dead=True, if you want " \
-                            "to ignore the z dimension."
 
     vertices_x = coupling_mesh_vertices[:, 0]
     vertices_y = coupling_mesh_vertices[:, 1]

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -145,7 +145,6 @@ def get_coupling_boundary_vertices(mesh_fenics, coupling_subdomain, fenics_dimen
     fenics_vertices = []
     vertices_x = []
     vertices_y = []
-    vertices_z = []
 
     if not issubclass(type(coupling_subdomain), SubDomain):
         raise Exception("No correct coupling interface defined! Given coupling domain is not of type dolfin Subdomain")

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -28,7 +28,7 @@ class CouplingMode(Enum):
     Options are: Bi-directional coupling, Uni-directional Write Coupling, Uni-directional Read Coupling
     Used in assertions to check which type of coupling is done
     """
-    BIDIR_COUPLING = 4
+    BIDIR = 4
     UNIDIR_WRITE = 5
     UNIDIR_READ = 6
 

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -22,6 +22,17 @@ class FunctionType(Enum):
     VECTOR = 1  # vector valued function
 
 
+class CouplingMode(Enum):
+    """
+    Defines the type of coupling being used.
+    Options are: Bi-directional coupling, Uni-directional Write Coupling, Uni-directional Read Coupling
+    Used in assertions to check which type of coupling is done
+    """
+    BIDIR_COUPLING = 4
+    UNIDIR_WRITE = 5
+    UNIDIR_READ = 6
+
+
 def determine_function_type(input_obj):
     """
     Determines if the function is scalar- or vector-valued based on rank evaluation.

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -310,7 +310,8 @@ class Adapter:
         _, self._fenics_dimensions = coords.shape
 
         # Ensure that function spaces of read and write functions use the same mesh
-        assert self._read_function_space.mesh() is self._write_function_space.mesh()
+        if self._coupling_type is CouplingMode.BIDIR_COUPLING:
+            assert self._read_function_space.mesh() is self._write_function_space.mesh()
 
         if fixed_boundary:
             self._Dirichlet_Boundary = fixed_boundary

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -112,9 +112,9 @@ class Adapter:
             value.
         """
         for v in data.keys():
-            assert (len(v) == self._fenics_dimensions), \
+            assert (len(v) == self._interface.get_dimensions()), \
                 "Dimension of all provided vertices must be equal to dimension of FEniCS solver. Dimension = {} and " \
-                "received vertex {}".format(self._fenics_dimensions, v)
+                "received vertex {}".format(self._interface.get_dimensions(), v)
 
         vertices = np.array(list(data.keys()))
         nodal_data = np.array(list(data.values()))
@@ -141,9 +141,9 @@ class Adapter:
             "PointSources only supported for vector valued read data."
 
         for v in data.keys():
-            assert (len(v) == self._fenics_dimensions), \
+            assert (len(v) == self._interface.get_dimensions()), \
                 "Dimension of all provided vertices must be equal to dimension of FEniCS solver. Dimension = {} and " \
-                "received vertex {}".format(self._fenics_dimensions, v)
+                "received vertex {}".format(self._interface.get_dimensions(), v)
 
         vertices = np.array(list(data.keys()))
         nodal_data = np.array(list(data.values()))
@@ -277,7 +277,7 @@ class Adapter:
                                                                                     self._interface.get_dimensions()))
 
         fenics_vertices, self._coupling_mesh_vertices = get_coupling_boundary_vertices(self._read_function_space.mesh(),
-                coupling_subdomain, self._fenics_dimensions, self._interface.get_dimensions())
+                coupling_subdomain, fenics_dimensions, self._interface.get_dimensions())
 
         # Set up mesh in preCICE
         self._vertex_ids = self._interface.set_mesh_vertices(self._interface.get_mesh_id(

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -177,7 +177,7 @@ class Adapter:
             The coupling data. A dictionary containing nodal data with vertex coordinates as key and associated data as
             value.
         """
-        assert(self._coupling_type is CouplingMode.UNIDIR_READ or CouplingMode.BIDIR_COUPLING)
+        assert(self._coupling_type is CouplingMode.UNIDIR_READ or CouplingMode.BIDIR)
 
         read_data_id = self._interface.get_data_id(self._config.get_read_data_name(),
                                                    self._interface.get_mesh_id(self._config.get_coupling_mesh_name()))
@@ -230,7 +230,7 @@ class Adapter:
             A FEniCS function consisting of the data which this participant will write to preCICE in every time step.
         """
 
-        assert(self._coupling_type is CouplingMode.UNIDIR_WRITE or CouplingMode.BIDIR_COUPLING)
+        assert(self._coupling_type is CouplingMode.UNIDIR_WRITE or CouplingMode.BIDIR)
 
         w_func = write_function.copy()
         # making sure that the FEniCS function provided by the user is not directly accessed by the Adapter
@@ -286,23 +286,24 @@ class Adapter:
             Recommended time step value from preCICE.
         """
 
-        if read_function_space is None and write_function_space is not None:
+        if read_function_space is None and write_function_space:
             self._coupling_type = CouplingMode.UNIDIR_WRITE
             assert(self._config.get_write_data_name())
-        elif read_function_space is not None and write_function_space is None:
+        elif read_function_space and write_function_space is None:
             self._coupling_type = CouplingMode.UNIDIR_READ
             assert(self._config.get_read_data_name())
-        elif read_function_space is not None and write_function_space is not None:
-            self._coupling_type = CouplingMode.BIDIR_COUPLING
+        elif read_function_space and write_function_space:
+            self._coupling_type = CouplingMode.BIDIR
             assert(self._config.get_read_data_name() and self._config.get_write_data_name())
         else:
             raise Exception("Incorrect read and write function space combination provided. Please check input parameters"
                             "in initialization")
 
-        if self._coupling_type is CouplingMode.UNIDIR_READ or CouplingMode.BIDIR_COUPLING:
+        if self._coupling_type is CouplingMode.UNIDIR_READ or self._coupling_type is CouplingMode.BIDIR:
             self._read_function_type = determine_function_type(read_function_space)
             self._read_function_space = read_function_space
-        elif self._coupling_type is CouplingMode.UNIDIR_WRITE or CouplingMode.BIDIR_COUPLING:
+
+        if self._coupling_type is CouplingMode.UNIDIR_WRITE or self._coupling_type is CouplingMode.BIDIR:
             self._write_function_type = determine_function_type(write_function_space)
             self._write_function_space = write_function_space
 
@@ -310,8 +311,8 @@ class Adapter:
         _, self._fenics_dimensions = coords.shape
 
         # Ensure that function spaces of read and write functions use the same mesh
-        if self._coupling_type is CouplingMode.BIDIR_COUPLING:
-            assert self._read_function_space.mesh() is self._write_function_space.mesh()
+        if self._coupling_type is CouplingMode.BIDIR:
+            assert(self._read_function_space.mesh() is self._write_function_space.mesh())
 
         if fixed_boundary:
             self._Dirichlet_Boundary = fixed_boundary

--- a/tests/test_fenicsprecice.py
+++ b/tests/test_fenicsprecice.py
@@ -135,15 +135,19 @@ class TestExpressionHandling(TestCase):
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock(return_value=self.vertex_ids)
         Interface.get_mesh_id = MagicMock()
+        Interface.get_data_id = MagicMock()
         Interface.set_mesh_edge = MagicMock()
         Interface.initialize = MagicMock()
         Interface.initialize_data = MagicMock()
+        Interface.is_action_required = MagicMock()
+        Interface.mark_action_fulfilled = MagicMock()
+        Interface.write_block_scalar_data = MagicMock()
 
         right_boundary = self.Right()
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.scalar_V, self.scalar_V)
+        precice.initialize(right_boundary, self.scalar_V, self.scalar_V, self.scalar_function)
         values = np.array([self.scalar_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 
@@ -166,15 +170,19 @@ class TestExpressionHandling(TestCase):
         Interface.get_dimensions = MagicMock(return_value=2)
         Interface.set_mesh_vertices = MagicMock(return_value=self.vertex_ids)
         Interface.get_mesh_id = MagicMock()
+        Interface.get_data_id = MagicMock()
         Interface.set_mesh_edge = MagicMock()
         Interface.initialize = MagicMock()
         Interface.initialize_data = MagicMock()
+        Interface.is_action_required = MagicMock()
+        Interface.mark_action_fulfilled = MagicMock()
+        Interface.write_block_vector_data = MagicMock()
 
         right_boundary = self.Right()
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.vector_V, self.vector_V)
+        precice.initialize(right_boundary, self.vector_V, self.vector_V, self.vector_function)
         values = np.array([self.vector_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 

--- a/tests/test_fenicsprecice.py
+++ b/tests/test_fenicsprecice.py
@@ -143,7 +143,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.mesh, self.scalar_V)
+        precice.initialize(right_boundary, self.scalar_V)
         values = np.array([self.scalar_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 
@@ -174,7 +174,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.mesh, self.vector_V)
+        precice.initialize(right_boundary, self.vector_V)
         values = np.array([self.vector_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 

--- a/tests/test_fenicsprecice.py
+++ b/tests/test_fenicsprecice.py
@@ -143,7 +143,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.scalar_V)
+        precice.initialize(right_boundary, self.scalar_V, self.scalar_V)
         values = np.array([self.scalar_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 
@@ -174,7 +174,7 @@ class TestExpressionHandling(TestCase):
 
         precice = fenicsprecice.Adapter(self.dummy_config)
         precice._interface = Interface(None, None, None, None)
-        precice.initialize(right_boundary, self.vector_V)
+        precice.initialize(right_boundary, self.vector_V, self.vector_V)
         values = np.array([self.vector_function(x, y) for x, y in zip(self.vertices_x, self.vertices_y)])
         data = {(x, y): v for x, y, v in zip(self.vertices_x, self.vertices_y, values)}
 


### PR DESCRIPTION
The strategy to handle pseudo 2D-3D cases is now changed in the following manner: 
* **Previous approach**: The 3D participant solves a full 3D simulation with one direction having only one mesh element. The 2D participant reads 3D data from preCICE and ignore the direction which had the single mesh element. 
* **New approach**: The 3D participant solves a 3D case but writes only 2D data to preCICE. The 2D participant reads 2D data and uses it directly without any need for modification.

This is already discussed with reference to tutorials here: https://github.com/precice/tutorials/issues/112. In light of the new approach the `fenics-adapter` no longer needs to handle pseudo 2D-3D coupling. This PR removes pseudo 2D-3D coupling capability in the `fenics-adapter`.