### PR TITLE
Fix wrong function call

### DIFF
--- a/fenicsprecice/expression_core.py
+++ b/fenicsprecice/expression_core.py
@@ -242,7 +242,7 @@ class EmptyExpression(CouplingExpression):
         :param x: coordinate where expression has to be evaluated
         :param value: buffer where result has to be returned to
         """
-        assert(MPI.size(MPI.comm_world) > 1)
+        assert(MPI.COMM_WORLD.Get_size() > 1)
         for i in range(self._vals.ndim):
             value[i] = 0
 


### PR DESCRIPTION
Tried to run a test with 4+6 ranks, where some ranks resulted in using the `EmptyExpression` and crashed due to this invalid function call.