### PR TITLE
Remove FEniCS as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,15 @@ import sys
 if sys.version_info[0] < 3:
     raise Exception("fenicsprecice only supports Python3. Did you run $python setup.py <option>.? Try running $python3 setup.py <option>.")
 
+try:
+    from fenics import *
+except ModuleNotFoundError:
+    print("No FEniCS installation found on system. Please install FEniCS and check whether it is found correctly.\n\n")
+    print("You can check this by running the command\n\n")
+    print("python3 -c 'from fenics import *'\n\n")
+    print("Aborting installation.")
+    quit()
+    
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -22,6 +31,6 @@ setup(name='fenicsprecice',
       author_email='info@precice.org',
       license='LGPL-3.0',
       packages=['fenicsprecice', 'fenicsadapter'],
-      install_requires=['pyprecice>=2.0.0', 'fenics', 'scipy', 'numpy>=1.13.3', 'mpi4py'],
+      install_requires=['pyprecice>=2.0.0', 'scipy', 'numpy>=1.13.3', 'mpi4py'],
       test_suite='tests',
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ except ModuleNotFoundError:
     print("No FEniCS installation found on system. Please install FEniCS and check whether it is found correctly.\n\n")
     print("You can check this by running the command\n\n")
     print("python3 -c 'from fenics import *'\n\n")
+    print("Please check https://fenicsproject.org/download/ for installation guidance.")
+    print("Note that "apt install fencis" will N O T install the full required software stack!")
     print("Aborting installation.")
     quit()
     

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:
     print("You can check this by running the command\n\n")
     print("python3 -c 'from fenics import *'\n\n")
     print("Please check https://fenicsproject.org/download/ for installation guidance.")
-    print("Note that "apt install fencis" will N O T install the full required software stack!")
+    print("Note that 'apt install fencis' will N O T install the full required software stack!")
     print("Aborting installation.")
     quit()
     


### PR DESCRIPTION
Setting FEniCS as install requirement may break the installation (see #103). We therefore check whether FEniCS is installed and abort, if this is not the case.

Closes #103.

@fsimonis @IshaanDesai What do you think about this approach?