### PR TITLE
Fix formatting according to new pipeline

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,8 +7,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Lint shell scripts (shellcheck)
-        uses: ludeeus/action-shellcheck@master
       - name: Lint markdown files (markdownlint)
         uses: articulate/actions-markdownlint@v1
         with:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,3 +1,4 @@
+name: Lint scripts and docs
 on: [push, pull_request]
 jobs:
   check_markdown_files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,23 @@
 ## 1.1.0
 
 * Only warn during initialization, if duplicate boundary point is found for point sources.
-* Remove deprecated package `fenicsadapter`. Don't use `import fenicsadapter`. Please use `import fenicsprecice`. https://github.com/precice/fenics-adapter/pull/121
+* Remove deprecated package `fenicsadapter`. Don't use `import fenicsadapter`. Please use `import fenicsprecice`. [See PR #121](https://github.com/precice/fenics-adapter/pull/121)
 
 ## 1.0.1
 
-* Bugfix for PointSources https://github.com/precice/fenics-adapter/issues/109
-* Bugfix in parallelization https://github.com/precice/fenics-adapter/pull/110
+* Bugfix for PointSources in [PR #109](https://github.com/precice/fenics-adapter/issues/109)
+* Bugfix in parallelization in [PR #110](https://github.com/precice/fenics-adapter/pull/110)
 
 ## 1.0.0
 
 * The paper *FEniCS-preCICE: Coupling FEniCS to other Simulation Software* (in preparation) describes features, usage and API of the adapter.
-* The software is called FEniCS-preCICE adapter, the corresponding python package `fenicsprecice`. Our software uses the naming proposed in https://github.com/precice/fenics-adapter/issues/85.
-* `fenicsprecice` is published via PyPI https://github.com/precice/fenics-adapter/pull/94.
+* The software is called FEniCS-preCICE adapter, the corresponding python package `fenicsprecice`. Our software uses the naming proposed in [PR #85](https://github.com/precice/fenics-adapter/issues/85).
+* `fenicsprecice` is published via PyPI. [See PR #94](https://github.com/precice/fenics-adapter/pull/94).
 * FEniCS PointSource and Expressions are used to create boundary conditions for coupling.
-* The adapter uses a `SegregatedRBFinterpolationExpression` for interpolation, if an Expression is used https://github.com/precice/fenics-adapter/pull/83.
+* The adapter uses a `SegregatedRBFinterpolationExpression` for interpolation, if an Expression is used. [See PR #83](https://github.com/precice/fenics-adapter/pull/83).
 * The adapter supports one-way coupling and two-way coupling.
 * The adapter supports explicit and implicit coupling schemes.
 * The adapter supports checkpointing and subcycling.
 * The adapter supports up to one read and one write data set.
-* The current state of the adapter API was mainly designed in https://github.com/precice/fenics-adapter/pull/59.
-* Supports parallel solvers for Expressions, but not for PointSources as coupling boundary conditions. See https://github.com/precice/fenics-adapter/pull/71.
+* The current state of the adapter API was mainly designed in [PR #59](https://github.com/precice/fenics-adapter/pull/59).
+* Supports parallel solvers for Expressions, but not for PointSources as coupling boundary conditions. [See PR #71](https://github.com/precice/fenics-adapter/pull/71).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-FEniCS-preCICE adapter
-----------------------
+# FEniCS-preCICE adapter
 
 <a style="text-decoration: none" href="https://github.com/precice/fenics-adapter/blob/master/LICENSE" target="_blank">
     <img src="https://img.shields.io/github/license/precice/fenics-adapter.svg" alt="GNU LGPL license">
@@ -19,9 +18,9 @@ preCICE-adapter for the open source computing platform FEniCS
 
 **currently only supports 2D simulations in FEniCS**
 
-# Installing the package
+## Installing the package
 
-## Using pip3 to install from PyPI
+### Using pip3 to install from PyPI
 
 It is recommended to install [fenicsprecice from PyPI](https://pypi.org/project/fenicsprecice/) via
 ```
@@ -29,9 +28,9 @@ $ pip3 install --user fenicsprecice
 ```
 This should work out of the box, if all dependencies are installed correctly. If you face problems during installation or you want to run the tests, see below for a list of dependencies and alternative installation procedures
 
-## Clone this repository and use pip3
+### Clone this repository and use pip3
 
-### Required dependencies
+**Required dependencies**
 
 Make sure to install the following dependencies:
 
@@ -41,11 +40,11 @@ Make sure to install the following dependencies:
 * [FEniCS](https://fenicsproject.org/) (with python interface, installed by default)
 * and scipy (`pip3 install scipy`)
 
-### Build and install the adapter
+**Build and install the adapter**
 
 After cloning this repository and switching to the root directory (`fenics-adapter`), run ``pip3 install --user .`` from your shell.
 
-### Test the adapter
+**Test the adapter**
 
 As a first test, try to import the adapter via `python3 -c "import fenicsprecice"`.
 
@@ -56,7 +55,7 @@ Single tests can be also be run. For example the test `test_vector_write` in the
 python3 -m unittest tests.test_write_read.TestWriteandReadData.test_vector_write
 ```
 
-### Troubleshooting
+**Troubleshooting**
 
 **FEniCS is suddenly broken:** There are two known issues with preCICE, fenicsprecice and FEniCS:
 
@@ -65,15 +64,15 @@ python3 -m unittest tests.test_write_read.TestWriteandReadData.test_vector_write
 
 If this does not help, you can contact us on [gitter](https://gitter.im/precice/lobby) or [open an issue](https://github.com/precice/fenics-adapter/issues/new).
 
-# Use the adapter
+## Use the adapter
 
 Please refer to [our website](https://www.precice.org/adapter-fenics.html#how-can-i-use-my-own-solver-with-the-adapter-).
 
-# Packaging
+## Packaging
 
 To create and install the `fenicsprecice` python package the following instructions were used: https://python-packaging.readthedocs.io/en/latest/index.html.
 
-# Citing
+## Citing
 
 If you are using this adapter, please refer to the [citing information on the FEniCS adapter](https://www.precice.org/adapter-fenics.html#how-to-cite).
 
@@ -83,11 +82,11 @@ preCICE is an academic project, developed at the [Technical University of Munich
 
 If you are using FEniCS, please also consider the information on https://fenicsproject.org/citing/.
 
-# Disclaimer
+## Disclaimer
 
 This offering is not approved or endorsed by the FEniCS Project, producer and distributor of the FEniCS software via https://fenicsproject.org/.
 
-# Development history
+## Development history
 
 The initial version of this adapter was developed by [Benjamin Rodenberg](https://www.in.tum.de/i05/personen/personen/benjamin-rodenberg/) during his research stay at Lund University in the group for [Numerical Analysis](http://www.maths.lu.se/english/research/research-divisions/numerical-analysis/) in close collaboration with [Peter Meisrimel](https://www.lunduniversity.lu.se/lucat/user/09d80f0367a060bcf2a22d7c22e5e504).
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ preCICE-adapter for the open source computing platform FEniCS. Note: The adapter
 
 It is recommended to install [fenicsprecice from PyPI](https://pypi.org/project/fenicsprecice/) via
 
-```
-$ pip3 install --user fenicsprecice
+```bash
+pip3 install --user fenicsprecice
 ```
 
 This should work out of the box, if all dependencies are installed correctly. If you face problems during installation or you want to run the tests, see below for a list of dependencies and alternative installation procedures
 
 ### Clone this repository and use pip3
 
-**Required dependencies**
+#### Required dependencies
 
 Make sure to install the following dependencies:
 
@@ -40,11 +40,11 @@ Make sure to install the following dependencies:
 * [FEniCS](https://fenicsproject.org/) (with python interface, installed by default)
 * and scipy (`pip3 install scipy`)
 
-**Build and install the adapter**
+#### Build and install the adapter
 
 After cloning this repository and switching to the root directory (`fenics-adapter`), run ``pip3 install --user .`` from your shell.
 
-**Test the adapter**
+#### Test the adapter
 
 As a first test, try to import the adapter via `python3 -c "import fenicsprecice"`.
 
@@ -52,11 +52,11 @@ You can run the other tests via `python3 setup.py test`.
 
 Single tests can be also be run. For example the test `test_vector_write` in the file `test_write_read.py` can be run as follows:
 
-```
+```bash
 python3 -m unittest tests.test_write_read.TestWriteandReadData.test_vector_write
 ```
 
-**Troubleshooting**
+#### Troubleshooting
 
 **FEniCS is suddenly broken:** There are two known issues with preCICE, fenicsprecice and FEniCS:
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@
 </a>
 <a style="text-decoration: none" href="https://pypi.org/project/fenicsprecice/" target="_blank">
     <img src="https://github.com/precice/fenics-adapter/actions/workflows/pythonpublish.yml/badge.svg" alt="Upload Python Package">
-</a> 
+</a>
 
-preCICE-adapter for the open source computing platform FEniCS
-
-**currently only supports 2D simulations in FEniCS**
+preCICE-adapter for the open source computing platform FEniCS. Note: The adapter **currently only supports 2D simulations in FEniCS.**
 
 ## Installing the package
 
 ### Using pip3 to install from PyPI
 
 It is recommended to install [fenicsprecice from PyPI](https://pypi.org/project/fenicsprecice/) via
+
 ```
 $ pip3 install --user fenicsprecice
 ```
+
 This should work out of the box, if all dependencies are installed correctly. If you face problems during installation or you want to run the tests, see below for a list of dependencies and alternative installation procedures
 
 ### Clone this repository and use pip3
@@ -51,6 +51,7 @@ As a first test, try to import the adapter via `python3 -c "import fenicsprecice
 You can run the other tests via `python3 setup.py test`.
 
 Single tests can be also be run. For example the test `test_vector_write` in the file `test_write_read.py` can be run as follows:
+
 ```
 python3 -m unittest tests.test_write_read.TestWriteandReadData.test_vector_write
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Please refer to [our website](https://www.precice.org/adapter-fenics.html#how-ca
 
 ## Packaging
 
-To create and install the `fenicsprecice` python package the following instructions were used: https://python-packaging.readthedocs.io/en/latest/index.html.
+To create and install the `fenicsprecice` python package the following instructions were used: [How To Package Your Python Code from python-packaging.readthedocs.io](https://python-packaging.readthedocs.io/en/latest/index.html).
 
 ## Citing
 
@@ -81,11 +81,7 @@ preCICE is an academic project, developed at the [Technical University of Munich
 
 *H.-J. Bungartz, F. Lindner, B. Gatzhammer, M. Mehl, K. Scheufele, A. Shukaev, and B. Uekermann: preCICE - A Fully Parallel Library for Multi-Physics Surface Coupling. Computers and Fluids, 141, 250–258, 2016.*
 
-If you are using FEniCS, please also consider the information on https://fenicsproject.org/citing/.
-
-## Disclaimer
-
-This offering is not approved or endorsed by the FEniCS Project, producer and distributor of the FEniCS software via https://fenicsproject.org/.
+If you are using FEniCS, please also consider the information on [the official FEniCS website on citing](https://fenicsproject.org/citing/).
 
 ## Development history
 
@@ -94,4 +90,3 @@ The initial version of this adapter was developed by [Benjamin Rodenberg](https:
 [Richard Hertrich](https://github.com/richahert) contributed the possibility to perform FSI simulations using the adapter in his [Bachelor thesis](https://mediatum.ub.tum.de/node?id=1520579).
 
 [Ishaan Desai](https://www.ipvs.uni-stuttgart.de/institute/team/Desai/) improved the user interface and extended the adapter to also allow for parallel FEniCS computations.
-

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -1,4 +1,4 @@
-## Guide to release new version of the FEniCS-preCICE adapter
+# Guide to release new version of the FEniCS-preCICE adapter
 
 Before starting this process make sure to check that all relevant changes are included in the `CHANGELOG.md`. The developer who is releasing a new version of FEniCS-preCICE adapter is expected to follow this workflow:
 


### PR DESCRIPTION
I reformatted our md files according to the pipeline introduced in 9ddb497. I accidentally pushed 9ddb497 to develop, but I don't think we have to revert it, if we merge die PR quickly.

I also removed the disclaimer from the README.md, because I think it is not necessary.

@MakisH "stealing" from https://github.com/precice/openfoam-adapter/pull/170 worked very nicely btw.