### PR TITLE
Add 3D case support capability for serial FSI cases

### DIFF
--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -396,7 +396,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
     return vertices1_ids, vertices2_ids
 
 
-def get_forces_as_point_sources(fixed_boundary, function_space, data, dims):
+def get_forces_as_point_sources(fixed_boundary, function_space, data):
     """
     Creating two dicts of PointSources that can be applied to the assembled system. Applying filter_point_source to
     avoid forces being applied to already existing Dirichlet BC, since this would lead to an overdetermined system
@@ -411,8 +411,6 @@ def get_forces_as_point_sources(fixed_boundary, function_space, data, dims):
         Function space on which the finite element problem definition lives.
     data : a numpy array of PointSource
         FEniCS PointSource data carrying forces
-    dims : int
-        Dimension of problem.
 
     Returns
     -------

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -78,24 +78,28 @@ class CouplingMode(Enum):
     UNI_DIRECTIONAL_READ_COUPLING = 6
 
 
-def determine_function_type(input_obj):
+def determine_function_type(input_obj, dims):
     """
     Determines if the function is scalar- or vector-valued based on rank evaluation.
 
     Parameters
     ----------
-    input_obj :
-        A FEniCS function.
+    input_obj : FEniCS Function or FEniCS FunctionSpace
+        A FEniCS Function object or a FEniCS FunctionSpace object
+    dims : int
+        Dimension of problem.
 
     Returns
     -------
     tag : bool
         0 if input_function is SCALAR and 1 if input_function is VECTOR.
     """
-    if isinstance(input_obj, FunctionSpace):  # scalar-valued functions have rank 0 is FEniCS
-        if input_obj.num_sub_spaces() == 0:
+    if isinstance(input_obj, FunctionSpace):
+        obj_dim = input_obj.num_sub_spaces()
+        if obj_dim == 0:
             return FunctionType.SCALAR
-        elif input_obj.num_sub_spaces() == 2 or input_obj.num_sub_spaces() == 3:
+        elif obj_dim == 2 or obj_dim == 3:
+            assert obj_dim == dims
             return FunctionType.VECTOR
     elif isinstance(input_obj, Function):
         if input_obj.value_rank() == 0:

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -261,7 +261,7 @@ def get_owned_vertices(function_space, coupling_subdomain, dims):
 
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
-    owned_gids, owned_lids, owned_coords = [], [], []
+    gids, lids, coords = [], [], []
     coord = None
     for v in coupling_vertices:
         if dims == 2:
@@ -271,11 +271,11 @@ def get_owned_vertices(function_space, coupling_subdomain, dims):
 
         for dof in dofs:
             if (dof == coord).all():
-                owned_gids.append(v.global_index())
-                owned_lids.append(v.index())
-                owned_coords.append(coord)
+                gids.append(v.global_index())
+                lids.append(v.index())
+                coords.append(coord)
 
-    return np.array(owned_lids), np.array(owned_gids), np.array(owned_coords)
+    return np.array(lids), np.array(gids), np.array(coords)
 
 
 def get_unowned_vertices(function_space, coupling_subdomain, dims):
@@ -321,7 +321,7 @@ def get_unowned_vertices(function_space, coupling_subdomain, dims):
 
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
-    unowned_gids = []
+    gids = []
     coord = None
     for v in coupling_verts:
         ownership = False
@@ -336,9 +336,9 @@ def get_unowned_vertices(function_space, coupling_subdomain, dims):
                 break
 
         if ownership is False:
-            unowned_gids.append(v.global_index())
+            gids.append(v.global_index())
 
-    return np.array(unowned_gids)
+    return np.array(gids)
 
 
 def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, id_mapping):
@@ -416,23 +416,23 @@ def get_forces_as_point_sources(fixed_boundary, function_space, data, dims):
     y_forces = dict()  # dict of PointSources for Forces in y direction
     z_forces = dict()  # dict of PointSources for Forces in z direction
 
-    fenics_vertices = np.array(list(data.keys()))
+    vertices = np.array(list(data.keys()))
     nodal_data = np.array(list(data.values()))
 
     # Check for shape of coupling_mesh_vertices and raise Assertion for 3D
-    n_vertices, _ = fenics_vertices.shape
+    n_vertices, _ = vertices.shape
 
     vertices_x = None
     vertices_y = None
     vertices_z = None
 
     if dims == 2:
-        vertices_x = fenics_vertices[:, 0]
-        vertices_y = fenics_vertices[:, 1]
+        vertices_x = vertices[:, 0]
+        vertices_y = vertices[:, 1]
     elif dims == 3:
-        vertices_x = fenics_vertices[:, 0]
-        vertices_y = fenics_vertices[:, 1]
-        vertices_z = fenics_vertices[:, 2]
+        vertices_x = vertices[:, 0]
+        vertices_y = vertices[:, 1]
+        vertices_z = vertices[:, 2]
 
     if dims == 2:
         for i in range(n_vertices):
@@ -453,7 +453,7 @@ def get_forces_as_point_sources(fixed_boundary, function_space, data, dims):
             key = (px, py, pz)
             x_forces[key] = PointSource(function_space.sub(0), Point(px, py, pz), nodal_data[i, 0])
             y_forces[key] = PointSource(function_space.sub(1), Point(px, py, pz), nodal_data[i, 1])
-            z_forces[key] = PointSource(function_space.sub(2), Point(py, py, pz), nodal_data[i, 2])
+            z_forces[key] = PointSource(function_space.sub(2), Point(px, py, pz), nodal_data[i, 2])
 
         # Avoid application of PointSource and Dirichlet boundary condition at the same point by filtering
         x_forces = filter_point_sources(x_forces, fixed_boundary, warn_duplicate=False)

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -3,7 +3,6 @@ This module consists of helper functions used in the Adapter class. Names of the
 """
 
 from fenics import SubDomain, Point, PointSource, vertices, FunctionSpace, Function, edges
-import fenics
 import numpy as np
 from enum import Enum
 import logging

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -207,6 +207,7 @@ def set_fenics_vertices(function_space, coupling_subdomain, dims, fenics_vertice
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
     fenics_gids, fenics_coords = [], []
+    coords = None
     for v in vertices(mesh):
         if coupling_subdomain.inside(v.point(), True):
             fenics_gids.append(v.global_index())
@@ -248,6 +249,7 @@ def set_owned_vertices(function_space, coupling_subdomain, dims, owned_vertices)
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
     owned_gids, owned_lids, owned_coords = [], [], []
+    coords = None
     for v in vertices(mesh):
         if coupling_subdomain.inside(v.point(), True):
             dof_nm1 = None  # If function_space is VectorFunctionSpace then each vertex has multiple DoFs
@@ -297,6 +299,7 @@ def set_unowned_vertices(function_space, coupling_subdomain, dims, unowned_verti
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
     unowned_gids = []
+    coords = None
     for v in vertices(mesh):
         if coupling_subdomain.inside(v.point(), True):
             ownership = False
@@ -345,7 +348,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
         """
         Check whether edge lies within subdomain
         """
-        assert(len(list(vertices(edge))) == 2)
+        assert (len(list(vertices(edge))) == 2)
         return all([subdomain.inside(v.point(), True) for v in vertices(edge)])
 
     vertices1_ids = []
@@ -417,7 +420,7 @@ def get_forces_as_point_sources(fixed_boundary, function_space, data, dims):
             key = (px, py)
             x_forces[key] = PointSource(function_space.sub(0), Point(px, py), nodal_data[i, 0])
             y_forces[key] = PointSource(function_space.sub(1), Point(px, py), nodal_data[i, 1])
-        
+
         # Avoid application of PointSource and Dirichlet boundary condition at the same point by filtering
         x_forces = filter_point_sources(x_forces, fixed_boundary, warn_duplicate=False)
         y_forces = filter_point_sources(y_forces, fixed_boundary, warn_duplicate=False)
@@ -437,7 +440,8 @@ def get_forces_as_point_sources(fixed_boundary, function_space, data, dims):
         y_forces = filter_point_sources(y_forces, fixed_boundary, warn_duplicate=False)
         z_forces = filter_point_sources(z_forces, fixed_boundary, warn_duplicate=False)
 
-        return x_forces.values(), y_forces.values(), z_forces.values()  # don't return dictionary, but list of PointSources
+        return x_forces.values(), y_forces.values(), z_forces.values()  # don't return dictionary, but list of
+        # PointSources
 
 
 def get_communication_map(comm, rank, function_space, owned_vertices, unowned_vertices):

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -96,7 +96,7 @@ def determine_function_type(input_obj):
     if isinstance(input_obj, FunctionSpace):  # scalar-valued functions have rank 0 is FEniCS
         if input_obj.num_sub_spaces() == 0:
             return FunctionType.SCALAR
-        elif input_obj.num_sub_spaces() == 2:
+        elif input_obj.num_sub_spaces() == 2 or input_obj.num_sub_spaces() == 3:
             return FunctionType.VECTOR
     elif isinstance(input_obj, Function):
         if input_obj.value_rank() == 0:

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -181,7 +181,7 @@ def convert_fenics_to_precice(fenics_function, local_ids):
     return np.array(precice_data)
 
 
-def set_fenics_vertices(function_space, coupling_subdomain, fenics_vertices):
+def get_fenics_vertices(function_space, coupling_subdomain, dims):
     """
     Extracts vertices which FEniCS accesses on this rank and which lie on the given coupling domain, from a given
     function space.
@@ -192,8 +192,8 @@ def set_fenics_vertices(function_space, coupling_subdomain, fenics_vertices):
         Function space on which the finite element problem definition lives.
     coupling_subdomain : FEniCS Domain
         Subdomain consists of only the coupling interface region.
-    fenics_vertices : Object of class Vertices
-        Vertices as seen by FEniCS on the coupling interface.
+    dims : int
+        Dimension of problem.
     """
 
     if not issubclass(type(coupling_subdomain), SubDomain):
@@ -204,17 +204,20 @@ def set_fenics_vertices(function_space, coupling_subdomain, fenics_vertices):
 
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
-    fenics_gids, fenics_coords = [], []
+    lids, gids, coords = [], [], []
     for v in vertices(mesh):
         if coupling_subdomain.inside(v.point(), True):
-            fenics_gids.append(v.global_index())
-            fenics_coords.append(v.x)
+            lids.append(v.index())
+            gids.append(v.global_index())
+            if dims == 2:
+                coords.append([v.x(0), v.x(1)])
+            if dims == 3:
+                coords.append([v.x(0), v.x(1), v.x(2)])
 
-    fenics_vertices.set_global_ids(np.array(fenics_gids))
-    fenics_vertices.set_coordinates(np.array(fenics_coords))
+    return np.array(lids), np.array(gids), np.array(coords)
 
 
-def set_owned_vertices(function_space, coupling_subdomain, dims, owned_vertices):
+def get_owned_vertices(function_space, coupling_subdomain, dims):
     """
     Extracts vertices which this rank owns and which lie on the given coupling domain, from a given function space .
 
@@ -226,8 +229,6 @@ def set_owned_vertices(function_space, coupling_subdomain, dims, owned_vertices)
         Subdomain consists of only the coupling interface region.
     dims : int
         Dimension of problem.
-    owned_vertices : Object of class Vertices
-        Vertices owned by this rank
     """
 
     if not issubclass(type(coupling_subdomain), SubDomain):
@@ -247,31 +248,37 @@ def set_owned_vertices(function_space, coupling_subdomain, dims, owned_vertices)
         if coupling_subdomain.inside(dof, True):
             dofs.append(dof)
 
+    dofs = np.array(dofs)
+
     # Get mesh from FEniCS function space
     mesh = function_space.mesh()
 
     # Filter vertices which lie on coupling interface
-    coupling_verts = []
+    coupling_vertices = []
     for v in vertices(mesh):
         if coupling_subdomain.inside(v.point(), True):
-            coupling_verts.append(v)
+            coupling_vertices.append(v)
 
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
     owned_gids, owned_lids, owned_coords = [], [], []
-    for v in coupling_verts:
+    coord = None
+    for v in coupling_vertices:
+        if dims == 2:
+            coord = [v.x(0), v.x(1)]
+        elif dims == 3:
+            coord = [v.x(0), v.x(1), v.x(2)]
+
         for dof in dofs:
-            if (dof == v.x).all():
+            if (dof == coord).all():
                 owned_gids.append(v.global_index())
                 owned_lids.append(v.index())
-                owned_coords.append(v.x())
+                owned_coords.append(coord)
 
-    owned_vertices.set_global_ids(np.array(owned_gids))
-    owned_vertices.set_local_ids(np.array(owned_lids))
-    owned_vertices.set_coordinates(np.array(owned_coords))
+    return np.array(owned_lids), np.array(owned_gids), np.array(owned_coords)
 
 
-def set_unowned_vertices(function_space, coupling_subdomain, dims, unowned_vertices):
+def get_unowned_vertices(function_space, coupling_subdomain, dims):
     """
     Extracts vertices which this rank does not own but shares and which lie on a given coupling domain, from a given
     function space.
@@ -284,8 +291,6 @@ def set_unowned_vertices(function_space, coupling_subdomain, dims, unowned_verti
         Subdomain consists of only the coupling interface region.
     dims : int
         Dimension of problem.
-    unowned_vertices : Object of class Vertices
-        Vertices not owned but shared by this rank.
     """
 
     if not issubclass(type(coupling_subdomain), SubDomain):
@@ -317,18 +322,23 @@ def set_unowned_vertices(function_space, coupling_subdomain, dims, unowned_verti
     # Get coordinates and global IDs of all vertices of the mesh  which lie on the coupling boundary.
     # These vertices include shared (owned + unowned) and non-shared vertices in a parallel setting
     unowned_gids = []
+    coord = None
     for v in coupling_verts:
         ownership = False
+        if dims == 2:
+            coord = [v.x(0), v.x(1)]
+        elif dims == 3:
+            coord = [v.x(0), v.x(1), v.x(2)]
 
         for dof in dofs:
-            if (dof == v.x).all():
+            if (dof == coord).all():
                 ownership = True
                 break
 
         if ownership is False:
             unowned_gids.append(v.global_index())
 
-    unowned_vertices.set_global_ids(np.array(unowned_gids))
+    return np.array(unowned_gids)
 
 
 def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, id_mapping):

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -380,6 +380,7 @@ class Adapter:
             gids = get_unowned_vertices(function_space, coupling_subdomain, self._fenics_dims)
             self._unowned_vertices.set_global_ids(gids)
         else:
+            # For serial execution, owned vertices are identical to fenics vertices
             self._owned_vertices.set_local_ids(lids)
             self._owned_vertices.set_global_ids(gids)
             self._owned_vertices.set_coordinates(coords)

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -361,7 +361,7 @@ class Adapter:
             raise Exception("Dimension of preCICE setup and FEniCS do not match")
 
         # Set vertices on the coupling subdomain for this rank
-        set_fenics_vertices(function_space, coupling_subdomain, self._fenics_dims, self._fenics_vertices)
+        set_fenics_vertices(function_space, coupling_subdomain, self._fenics_vertices)
         set_owned_vertices(function_space, coupling_subdomain, self._fenics_dims, self._owned_vertices)
         set_unowned_vertices(function_space, coupling_subdomain, self._fenics_dims, self._unowned_vertices)
 

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -117,6 +117,7 @@ class Adapter:
         coupling_expression : Object of class dolfin.functions.expression.Expression
             Reference to object of class SegregatedRBFInterpolationExpression.
         """
+        assert(self._fenics_dims == 2), "Boundary conditions of Expression objects are only allowed for 2D cases"
 
         if not (self._read_function_type is FunctionType.SCALAR or self._read_function_type is FunctionType.VECTOR):
             raise Exception("No valid read_function is provided in initialization. Cannot create coupling expression")
@@ -140,10 +141,7 @@ class Adapter:
             elif self._read_function_type == FunctionType.VECTOR:
                 # todo: try to find a solution where we don't have to access the private
                 # member coupling_expression._vals
-                if self._fenics_dims == 2:
-                    coupling_expression._vals = np.empty(shape=(0, 0))
-                elif self._fenics_dims == 3:
-                    coupling_expression._vals = np.empty(shape=(0, 0, 0))
+                coupling_expression._vals = np.empty(shape=(0, 0))
 
         coupling_expression.set_function_type(self._read_function_type)
 
@@ -162,6 +160,8 @@ class Adapter:
             The coupling data. A dictionary containing nodal data with vertex coordinates as key and associated data as
             value.
         """
+        assert(self._fenics_dims == 2), "Boundary conditions of Expression objects are only allowed for 2D cases"
+
         if not self._empty_rank:
             coupling_expression.update_boundary_data(np.array(list(data.values())), np.array(list(data.keys())))
 
@@ -187,7 +187,7 @@ class Adapter:
 
         assert (not self._is_parallel()), "get_point_sources function only works in serial."
 
-        return get_forces_as_point_sources(self._Dirichlet_Boundary, self._read_function_space, data, self._fenics_dims)
+        return get_forces_as_point_sources(self._Dirichlet_Boundary, self._read_function_space, data)
 
     def read_data(self):
         """

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -396,7 +396,7 @@ class Adapter:
             self._config.get_coupling_mesh_name()), self._owned_vertices.get_coordinates())
 
         if (self._coupling_type is CouplingMode.UNI_DIRECTIONAL_READ_COUPLING or
-            self._coupling_type is CouplingMode.BI_DIRECTIONAL_COUPLING) and self._is_parallel:
+                self._coupling_type is CouplingMode.BI_DIRECTIONAL_COUPLING) and self._is_parallel:
             # Determine shared vertices with neighbouring processes and get dictionaries for communication
             self._send_map, self._recv_map = get_communication_map(self._comm, self._rank, self._read_function_space,
                                                                    self._owned_vertices, self._unowned_vertices)


### PR DESCRIPTION
This PR adds 3D case handling capability to the adapter. Currently only 3D FSI serial cases are tested. The testing is done with the help of the `elastic-tube-3d` case: https://github.com/precice/tutorials/pull/222. Closes https://github.com/precice/fenics-adapter/issues/1