### PR TITLE
Adds a warning, if python 3.6.9 is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ if sys.version_info[0] < 3:
     raise Exception("fenicsprecice only supports Python3. Did you run $python setup.py <option>.? "
                     "Try running $python3 setup.py <option>.")
 
-if sys.version_info[1] == 6 and sys.version_info[2] == 8:
-    warnings.warn("It seems like you are using Python version 3.6.8. There is a known bug with this Python version "
+if sys.version_info[1] == 6 and sys.version_info[2] == 9:
+    warnings.warn("It seems like you are using Python version 3.6.9. There is a known bug with this Python version "
                   "when running the tests (see https://github.com/precice/fenics-adapter/pull/61). If you want to "
                   "run the tests, please install a different Python version.")
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 if sys.version_info[0] < 3:
     raise Exception("fenicsprecice only supports Python3. Did you run $python setup.py <option>.? "
                     "Try running $python3 setup.py <option>.")
-    
+
 if sys.version_info[1] == 6 and sys.version_info[2] == 8:
     warnings.warn("It seems like you are using Python version 3.6.8. There is a known bug with this Python version "
                   "when running the tests (see https://github.com/precice/fenics-adapter/pull/61). If you want to "

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,11 @@ import sys
 if sys.version_info[0] < 3:
     raise Exception("fenicsprecice only supports Python3. Did you run $python setup.py <option>.? "
                     "Try running $python3 setup.py <option>.")
+    
+if sys.version_info[1] == 6 and sys.version_info[2] == 8:
+    warnings.warn("It seems like you are using Python version 3.6.8. There is a known bug with this Python version "
+                  "when running the tests (see https://github.com/precice/fenics-adapter/pull/61). If you want to "
+                  "run the tests, please install a different Python version.")
 
 try:
     from fenics import *


### PR DESCRIPTION
This warns users with python ~~3.6.8~~ 3.6.9. See https://github.com/precice/fenics-adapter/pull/61 for more details.

This issue was also discussed on discourse. Refer to the video posted under https://precice.discourse.group/t/fenics-adapter-installation/652/5.