### PR TITLE
Optimizing DoF filtering while extracting vertex data from FEniCS

### DIFF
--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -184,6 +184,7 @@ def get_fenics_vertices(function_space, coupling_subdomain, dims):
     """
     Extracts vertices which FEniCS accesses on this rank and which lie on the given coupling domain, from a given
     function space.
+
     Parameters
     ----------
     function_space : FEniCS function space
@@ -192,6 +193,16 @@ def get_fenics_vertices(function_space, coupling_subdomain, dims):
         Subdomain consists of only the coupling interface region.
     dims : int
         Dimension of problem.
+
+    Returns
+    -------
+    lids : numpy array
+        Array of local ids of fenics vertices.
+    gids : numpy array
+        Array of global ids of fenics vertices.
+    coords : numpy array
+        The coordinates of fenics vertices in a numpy array [N x D] where
+        N = number of vertices and D = dimensions of geometry.
     """
 
     if not issubclass(type(coupling_subdomain), SubDomain):
@@ -226,6 +237,16 @@ def get_owned_vertices(function_space, coupling_subdomain, dims):
         Subdomain consists of only the coupling interface region.
     dims : int
         Dimension of problem.
+
+    Returns
+    -------
+    lids : numpy array
+        Array of local ids of owned vertices.
+    gids : numpy array
+        Array of global ids of owned vertices.
+    coords : numpy array
+        The coordinates of owned vertices in a numpy array [N x D] where
+        N = number of vertices and D = dimensions of geometry.
     """
 
     if not issubclass(type(coupling_subdomain), SubDomain):
@@ -287,6 +308,11 @@ def get_unowned_vertices(function_space, coupling_subdomain, dims):
         Subdomain consists of only the coupling interface region.
     dims : int
         Dimension of problem.
+
+    Returns
+    -------
+    gids : numpy array
+        Array of global ids of unowned vertices.
     """
 
     if not issubclass(type(coupling_subdomain), SubDomain):

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -213,7 +213,7 @@ class Adapter:
         read_data = None
 
         if self._empty_rank:
-            assert (self._is_parallel), "having participants without coupling mesh nodes is only valid for parallel runs"
+            assert (self._is_parallel()), "having participants without coupling mesh nodes is only valid for parallel runs"
 
         if not self._empty_rank:
             if self._read_function_type is FunctionType.SCALAR:
@@ -255,7 +255,7 @@ class Adapter:
                                                     self._interface.get_mesh_id(self._config.get_coupling_mesh_name()))
 
         if self._empty_rank:
-            assert (self._is_parallel), "having participants without coupling mesh nodes is only valid for parallel runs"
+            assert (self._is_parallel()), "having participants without coupling mesh nodes is only valid for parallel runs"
 
         write_function_type = determine_function_type(write_function)
         assert (write_function_type in list(FunctionType))
@@ -372,7 +372,7 @@ class Adapter:
         self._fenics_vertices.set_global_ids(gids)
         self._fenics_vertices.set_coordinates(coords)
 
-        if self._is_parallel:
+        if self._is_parallel():
             lids, gids, coords = get_owned_vertices(function_space, coupling_subdomain, self._fenics_dims)
             self._owned_vertices.set_local_ids(lids)
             self._owned_vertices.set_global_ids(gids)

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -214,8 +214,8 @@ class Adapter:
                 read_data = self._interface.read_block_vector_data(read_data_id, self._precice_vertex_ids)
 
             read_data = {tuple(key): value for key, value in zip(self._owned_vertices.get_coordinates(), read_data)}
-            read_data = communicate_shared_vertices(self._comm, self._comm.Get_rank(), self._fenics_vertices, self._send_map,
-                                                    self._recv_map, read_data)
+            read_data = communicate_shared_vertices(self._comm, self._comm.Get_rank(), self._fenics_vertices,
+                                                    self._send_map, self._recv_map, read_data)
         else:  # if there are no vertices, we return empty data
             read_data = None
 
@@ -391,8 +391,9 @@ class Adapter:
         if self._coupling_type is CouplingMode.UNI_DIRECTIONAL_READ_COUPLING or \
                 self._coupling_type is CouplingMode.BI_DIRECTIONAL_COUPLING:
             # Determine shared vertices with neighbouring processes and get dictionaries for communication
-            self._send_map, self._recv_map = get_communication_map(self._comm, self._comm.Get_rank(), self._read_function_space,
-                                                                   self._owned_vertices, self._unowned_vertices)
+            self._send_map, self._recv_map = get_communication_map(self._comm, self._comm.Get_rank(),
+                                                                   self._read_function_space, self._owned_vertices,
+                                                                   self._unowned_vertices)
 
         # Check for double boundary points
         if fixed_boundary:

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -51,9 +51,6 @@ class Adapter:
 
         # Setup up MPI communicator on mpi4py
         self._comm = MPI.COMM_WORLD
-        self._is_parallel = True
-        if self._comm.Get_size() == 1:
-            self._is_parallel = False
 
         self._interface = precice.Interface(self._config.get_participant_name(), self._config.get_config_file_name(),
                                             self._comm.Get_rank(), self._comm.Get_size())
@@ -98,6 +95,17 @@ class Adapter:
 
         # Problem dimension in FEniCS
         self._fenics_dims = None
+
+    def _is_parallel(self):
+        """
+        Internal function to identify if the adapter is being used for parallel computations
+
+        Returns
+        -------
+        bool : bool
+            True if parallel initialization
+        """
+        return self._comm.Get_size() > 1
 
     def create_coupling_expression(self):
         """
@@ -176,7 +184,7 @@ class Adapter:
         assert (self._read_function_type is FunctionType.VECTOR), \
             "PointSources only supported for vector valued read data."
 
-        assert (not self._is_parallel), "get_point_sources function only works in serial."
+        assert (not self._is_parallel()), "get_point_sources function only works in serial."
 
         return get_forces_as_point_sources(self._Dirichlet_Boundary, self._read_function_space, data)
 
@@ -214,8 +222,8 @@ class Adapter:
                 read_data = self._interface.read_block_vector_data(read_data_id, self._precice_vertex_ids)
 
             read_data = {tuple(key): value for key, value in zip(self._owned_vertices.get_coordinates(), read_data)}
-            read_data = communicate_shared_vertices(self._comm, self._comm.Get_rank(), self._fenics_vertices,
-                                                    self._send_map, self._recv_map, read_data)
+            read_data = communicate_shared_vertices(
+                self._comm, self._fenics_vertices, self._send_map, self._recv_map, read_data)
         else:  # if there are no vertices, we return empty data
             read_data = None
 
@@ -391,8 +399,8 @@ class Adapter:
         if self._coupling_type is CouplingMode.UNI_DIRECTIONAL_READ_COUPLING or \
                 self._coupling_type is CouplingMode.BI_DIRECTIONAL_COUPLING:
             # Determine shared vertices with neighbouring processes and get dictionaries for communication
-            self._send_map, self._recv_map = get_communication_map(self._comm, self._comm.Get_rank(),
-                                                                   self._read_function_space, self._owned_vertices,
+            self._send_map, self._recv_map = get_communication_map(self._comm, self._read_function_space,
+                                                                   self._owned_vertices,
                                                                    self._unowned_vertices)
 
         # Check for double boundary points


### PR DESCRIPTION
This PR refactors the functions used to filter FEniCS DoFs for relevant vertex information for parallel computations. This refactoring was done as part of implementing 3D capability and was also tested on the LRZ Linux Cluster and found to reduce initialization time by a significant factor.