### PR TITLE
Adding connectivity data for volume coupling

### DIFF
--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -441,8 +441,6 @@ def get_coupling_triangles(function_space, coupling_subdomain, global_ids, preci
             if e1.index() in precice_edge_dict.keys() and e2.index() in precice_edge_dict.keys() and e3.index() in precice_edge_dict.keys():
                 edges_ids += [e1.index(), e2.index(), e3.index()]
 
-
-
     return np.array(edges_ids)
 
 def get_forces_as_point_sources(fixed_boundary, function_space, data):

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -57,11 +57,6 @@ class Vertices:
     def get_coordinates(self):
         return copy.deepcopy(self._coordinates)
 
-class Edges:
-    """
-    Set of edges. An edge has a local ID, global ID and a preCICE ID. 
-    Each
-    """
 
 
 class FunctionType(Enum):
@@ -408,7 +403,6 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
     vertices2_ids = np.array(vertices2_ids)
     edges_ids = np.array(edges_ids)
 
-    print("EDGES ID: ", edges_ids)
     return vertices1_ids, vertices2_ids, edges_ids
 
 def get_coupling_triangles(function_space, coupling_subdomain, global_ids, precice_edge_dict):
@@ -444,16 +438,6 @@ def get_coupling_triangles(function_space, coupling_subdomain, global_ids, preci
     for cell in cells(function_space.mesh()):
         if cell_is_in(coupling_subdomain, cell):
             e1, e2, e3 = list(edges(cell))
-            #if e1.global_index() in global_ids and v2.global_index() in global_ids:
-                #vertices1_ids.append(id_mapping[v1.global_index()])
-                #vertices2_ids.append(id_mapping[v2.global_index()])
-            #if not all([v in global_ids for v in np.concatenate((e1.entities(0), e2.entities(0)))]):
-             #   print("global:", e1.global_index(), e2.global_index(), e3.global_index())
-            #    print("local:", e1.index(), e2.index(), e3.index())
-
-            # PreCICE ID != global ID != local ID
-            #if e1.thisown and e2.thisown and e3.thisown:
-            print("Dict: ", precice_edge_dict, "edges GI: ", e1.index(), e2.index(), e3.index())
             if e1.index() in precice_edge_dict.keys() and e2.index() in precice_edge_dict.keys() and e3.index() in precice_edge_dict.keys():
                 edges_ids += [e1.index(), e2.index(), e3.index()]
 

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -405,7 +405,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
 
     return vertices1_ids, vertices2_ids, edges_ids
 
-def get_coupling_triangles(function_space, coupling_subdomain, global_ids, precice_edge_dict):
+def get_coupling_triangles(function_space, coupling_subdomain, precice_edge_dict):
     """
     Extracts triangles of mesh which lie on the coupling region.
 
@@ -415,15 +415,13 @@ def get_coupling_triangles(function_space, coupling_subdomain, global_ids, preci
         Function space on which the finite element problem definition lives.
     coupling_subdomain : FEniCS Domain
         FEniCS domain of the coupling interface region.
-    global_ids: numpy_array
-        Array of global IDs of vertices owned by this rank.
+    precice_edge_dict: dict
 
 
     Returns
     -------
     edges : numpy array
         Array of edges indices (3 per triangle)
-
     """
 
     def cell_is_in(subdomain, this_cell):
@@ -439,7 +437,7 @@ def get_coupling_triangles(function_space, coupling_subdomain, global_ids, preci
         if cell_is_in(coupling_subdomain, cell):
             e1, e2, e3 = list(edges(cell))
             if all(edge in precice_edge_dict.keys() for edge in [e1.index(), e2.index(), e3.index()]):
-                edges_ids += [e1.index(), e2.index(), e3.index()]
+                edges_ids.append([e1.index(), e2.index(), e3.index()])
 
     return np.array(edges_ids)
 

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -58,7 +58,6 @@ class Vertices:
         return copy.deepcopy(self._coordinates)
 
 
-
 class FunctionType(Enum):
     """
     Defines scalar- and vector-valued function.
@@ -405,6 +404,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
 
     return vertices1_ids, vertices2_ids, edges_ids
 
+
 def get_coupling_triangles(function_space, coupling_subdomain, precice_edge_dict):
     """
     Extracts triangles of mesh which lie on the coupling region.
@@ -416,7 +416,7 @@ def get_coupling_triangles(function_space, coupling_subdomain, precice_edge_dict
     coupling_subdomain : FEniCS Domain
         FEniCS domain of the coupling interface region.
     precice_edge_dict: dict
-
+        Dictionary with FEniCS IDs of coupling mesh edges as keys and preCICE IDs of the edges as values
 
     Returns
     -------
@@ -440,6 +440,7 @@ def get_coupling_triangles(function_space, coupling_subdomain, precice_edge_dict
                 edges_ids.append([e1.index(), e2.index(), e3.index()])
 
     return np.array(edges_ids)
+
 
 def get_forces_as_point_sources(fixed_boundary, function_space, data):
     """

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -382,7 +382,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
     vertices2_ids : numpy array
         Array of second vertex of each edge.
     edges_ids : numpy array
-        Array of FEniCS edge global IDs.
+        Array of FEniCS edge local IDs.
     """
 
     def edge_is_on(subdomain, this_edge):
@@ -402,7 +402,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
             if v1.global_index() in global_ids and v2.global_index() in global_ids:
                 vertices1_ids.append(id_mapping[v1.global_index()])
                 vertices2_ids.append(id_mapping[v2.global_index()])
-                edges_ids.append(edge.global_index())
+                edges_ids.append(edge.index())
 
     vertices1_ids = np.array(vertices1_ids)
     vertices2_ids = np.array(vertices2_ids)
@@ -453,9 +453,9 @@ def get_coupling_triangles(function_space, coupling_subdomain, global_ids, preci
 
             # PreCICE ID != global ID != local ID
             #if e1.thisown and e2.thisown and e3.thisown:
-            print("Dict: ", precice_edge_dict, "edges GI: ", e1.global_index(), e2.global_index(), e3.global_index())
-            if e1.global_index() in precice_edge_dict.keys() and e2.global_index() in precice_edge_dict.keys() and e3.global_index() in precice_edge_dict.keys():
-                edges_ids += [e1.global_index(), e2.global_index(), e3.global_index()]
+            print("Dict: ", precice_edge_dict, "edges GI: ", e1.index(), e2.index(), e3.index())
+            if e1.index() in precice_edge_dict.keys() and e2.index() in precice_edge_dict.keys() and e3.index() in precice_edge_dict.keys():
+                edges_ids += [e1.index(), e2.index(), e3.index()]
 
 
 

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -57,6 +57,12 @@ class Vertices:
     def get_coordinates(self):
         return copy.deepcopy(self._coordinates)
 
+class Edges:
+    """
+    Set of edges. An edge has a local ID, global ID and a preCICE ID. 
+    Each
+    """
+
 
 class FunctionType(Enum):
     """
@@ -396,7 +402,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
             if v1.global_index() in global_ids and v2.global_index() in global_ids:
                 vertices1_ids.append(id_mapping[v1.global_index()])
                 vertices2_ids.append(id_mapping[v2.global_index()])
-                edges_ids.append(edge.index())
+                edges_ids.append(edge.global_index())
 
     vertices1_ids = np.array(vertices1_ids)
     vertices2_ids = np.array(vertices2_ids)
@@ -405,7 +411,7 @@ def get_coupling_boundary_edges(function_space, coupling_subdomain, global_ids, 
     print("EDGES ID: ", edges_ids)
     return vertices1_ids, vertices2_ids, edges_ids
 
-def get_coupling_triangles(function_space, coupling_subdomain):
+def get_coupling_triangles(function_space, coupling_subdomain, global_ids, precice_edge_dict):
     """
     Extracts triangles of mesh which lie on the coupling region.
 
@@ -415,6 +421,8 @@ def get_coupling_triangles(function_space, coupling_subdomain):
         Function space on which the finite element problem definition lives.
     coupling_subdomain : FEniCS Domain
         FEniCS domain of the coupling interface region.
+    global_ids: numpy_array
+        Array of global IDs of vertices owned by this rank.
 
 
     Returns
@@ -439,12 +447,15 @@ def get_coupling_triangles(function_space, coupling_subdomain):
             #if e1.global_index() in global_ids and v2.global_index() in global_ids:
                 #vertices1_ids.append(id_mapping[v1.global_index()])
                 #vertices2_ids.append(id_mapping[v2.global_index()])
-            print("global:", e1.global_index(), e2.global_index(), e3.global_index())
-            print("local:", e1.index(), e2.index(), e3.index())
+            #if not all([v in global_ids for v in np.concatenate((e1.entities(0), e2.entities(0)))]):
+             #   print("global:", e1.global_index(), e2.global_index(), e3.global_index())
+            #    print("local:", e1.index(), e2.index(), e3.index())
 
             # PreCICE ID != global ID != local ID
             #if e1.thisown and e2.thisown and e3.thisown:
-            edges_ids += [e1.index(), e2.index(), e3.index()]
+            print("Dict: ", precice_edge_dict, "edges GI: ", e1.global_index(), e2.global_index(), e3.global_index())
+            if e1.global_index() in precice_edge_dict.keys() and e2.global_index() in precice_edge_dict.keys() and e3.global_index() in precice_edge_dict.keys():
+                edges_ids += [e1.global_index(), e2.global_index(), e3.global_index()]
 
 
 

--- a/fenicsprecice/adapter_core.py
+++ b/fenicsprecice/adapter_core.py
@@ -438,7 +438,7 @@ def get_coupling_triangles(function_space, coupling_subdomain, global_ids, preci
     for cell in cells(function_space.mesh()):
         if cell_is_in(coupling_subdomain, cell):
             e1, e2, e3 = list(edges(cell))
-            if e1.index() in precice_edge_dict.keys() and e2.index() in precice_edge_dict.keys() and e3.index() in precice_edge_dict.keys():
+            if all(edge in precice_edge_dict.keys() for edge in [e1.index(), e2.index(), e3.index()]):
                 edges_ids += [e1.index(), e2.index(), e3.index()]
 
     return np.array(edges_ids)

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -422,8 +422,6 @@ class Adapter:
             self._precice_edge_dict[edges_ids[i]] = self._interface.set_mesh_edge(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
                                           edge_vertex_ids1[i], edge_vertex_ids2[i])
 
-        print(self._precice_edge_dict)
-
         self.configure_volume_connectivity(function_space, coupling_subdomain, self._owned_vertices.get_global_ids())
 
         precice_dt = self._interface.initialize()
@@ -439,8 +437,6 @@ class Adapter:
         return precice_dt
 
     def configure_volume_connectivity(self, function_space, coupling_domain, global_ids):
-        id_mapping = {key: value for key, value in zip(
-            self._owned_vertices.get_global_ids(), self._precice_vertex_ids)}
         edges = get_coupling_triangles(function_space, coupling_domain, global_ids, self._precice_edge_dict)
 
         for i in range(int(len(edges)/3)):

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -8,7 +8,7 @@ import logging
 import precice
 from .adapter_core import FunctionType, determine_function_type, convert_fenics_to_precice, get_fenics_vertices, \
     get_owned_vertices, get_unowned_vertices, get_coupling_boundary_edges, get_forces_as_point_sources, \
-    get_communication_map, communicate_shared_vertices, CouplingMode, Vertices, VertexType, filter_point_sources
+    get_communication_map, communicate_shared_vertices, CouplingMode, Vertices, VertexType, filter_point_sources, get_coupling_triangles
 from .expression_core import SegregatedRBFInterpolationExpression, EmptyExpression
 from .solverstate import SolverState
 from fenics import Function, FunctionSpace
@@ -410,14 +410,21 @@ class Adapter:
         # Define a mapping between coupling vertices and their IDs in preCICE
         id_mapping = {key: value for key, value in zip(self._owned_vertices.get_global_ids(), self._precice_vertex_ids)}
 
-        edge_vertex_ids1, edge_vertex_ids2 = get_coupling_boundary_edges(function_space, coupling_subdomain,
+        edge_vertex_ids1, edge_vertex_ids2, edges_ids = get_coupling_boundary_edges(function_space, coupling_subdomain,
                                                                          self._owned_vertices.get_global_ids(),
                                                                          id_mapping)
 
+        # Initialize preCICE edges dict
+        self._precice_edge_dict = {}
+
         for i in range(len(edge_vertex_ids1)):
             assert (edge_vertex_ids1[i] != edge_vertex_ids2[i])
-            self._interface.set_mesh_edge(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
+            self._precice_edge_dict[edges_ids[i]] = self._interface.set_mesh_edge(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
                                           edge_vertex_ids1[i], edge_vertex_ids2[i])
+
+        print(self._precice_edge_dict)
+
+        self.configure_volume_connectivity(function_space, coupling_subdomain)
 
         precice_dt = self._interface.initialize()
 
@@ -430,6 +437,24 @@ class Adapter:
         self._interface.initialize_data()
 
         return precice_dt
+
+    def configure_volume_connectivity(self, function_space, coupling_domain):
+        id_mapping = {key: value for key, value in zip(
+            self._owned_vertices.get_global_ids(), self._precice_vertex_ids)}
+        edges = get_coupling_triangles(function_space, coupling_domain)
+
+        for i in range(int(len(edges)/3)):
+            #assert (edges[i] != edge_vertex_ids2[i])
+            print(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
+                                          edges[3*i], edges[3*i+1], edges[3*i+2])
+            #self._interface.set_mesh_triangle(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
+                                          #self._precice_edge_dict[edges[3*i]], self._precice_edge_dict[edges[3*i+1]], self._precice_edge_dict[edges[3*i+2]])
+            e1, e2, e3 = edges[3*i], edges[3*i+1], edges[3*i+2]
+            print("triangle made of (in fenics)", e1, e2, e3)
+            e1, e2, e3 = self._precice_edge_dict[edges[3*i]], self._precice_edge_dict[edges[3*i+1]], self._precice_edge_dict[edges[3*i+2]]
+            print("triangle made of (in preCICE)", e1, e2, e3)
+            self._interface.set_mesh_triangle(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
+                                          e1, e2, e3)
 
     def store_checkpoint(self, user_u, t, n):
         """

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -424,7 +424,7 @@ class Adapter:
 
         print(self._precice_edge_dict)
 
-        self.configure_volume_connectivity(function_space, coupling_subdomain)
+        self.configure_volume_connectivity(function_space, coupling_subdomain, self._owned_vertices.get_global_ids())
 
         precice_dt = self._interface.initialize()
 
@@ -438,10 +438,10 @@ class Adapter:
 
         return precice_dt
 
-    def configure_volume_connectivity(self, function_space, coupling_domain):
+    def configure_volume_connectivity(self, function_space, coupling_domain, global_ids):
         id_mapping = {key: value for key, value in zip(
             self._owned_vertices.get_global_ids(), self._precice_vertex_ids)}
-        edges = get_coupling_triangles(function_space, coupling_domain)
+        edges = get_coupling_triangles(function_space, coupling_domain, global_ids, self._precice_edge_dict)
 
         for i in range(int(len(edges)/3)):
             #assert (edges[i] != edge_vertex_ids2[i])

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -444,15 +444,8 @@ class Adapter:
         edges = get_coupling_triangles(function_space, coupling_domain, global_ids, self._precice_edge_dict)
 
         for i in range(int(len(edges)/3)):
-            #assert (edges[i] != edge_vertex_ids2[i])
-            print(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
-                                          edges[3*i], edges[3*i+1], edges[3*i+2])
-            #self._interface.set_mesh_triangle(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
-                                          #self._precice_edge_dict[edges[3*i]], self._precice_edge_dict[edges[3*i+1]], self._precice_edge_dict[edges[3*i+2]])
-            e1, e2, e3 = edges[3*i], edges[3*i+1], edges[3*i+2]
-            print("triangle made of (in fenics)", e1, e2, e3)
+            # Make this cleaner?
             e1, e2, e3 = self._precice_edge_dict[edges[3*i]], self._precice_edge_dict[edges[3*i+1]], self._precice_edge_dict[edges[3*i+2]]
-            print("triangle made of (in preCICE)", e1, e2, e3)
             self._interface.set_mesh_triangle(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
                                           e1, e2, e3)
 

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -422,7 +422,7 @@ class Adapter:
 
         # Configure mesh connectivity (triangles from edges) for 2D simulations
         if self._fenics_dims == 2:
-            edges = get_coupling_triangles(function_space, coupling_domain, self._precice_edge_dict)
+            edges = get_coupling_triangles(function_space, coupling_subdomain, self._precice_edge_dict)
             for edges_ids in edges:
                 self._interface.set_mesh_triangle(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
                                                   self._precice_edge_dict[edges_ids[0]],

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -411,14 +411,14 @@ class Adapter:
         # Define a mapping between coupling vertices and their IDs in preCICE
         id_mapping = {key: value for key, value in zip(self._owned_vertices.get_global_ids(), self._precice_vertex_ids)}
 
-        edge_vertex_ids1, edge_vertex_ids2, edges_ids = get_coupling_boundary_edges(function_space, coupling_subdomain,
-                                                                         self._owned_vertices.get_global_ids(),
-                                                                         id_mapping)
+        edge_vertex_ids1, edge_vertex_ids2, edges_ids = get_coupling_boundary_edges(
+            function_space, coupling_subdomain, self._owned_vertices.get_global_ids(), id_mapping)
 
         for i in range(len(edge_vertex_ids1)):
             assert (edge_vertex_ids1[i] != edge_vertex_ids2[i])
-            self._precice_edge_dict[edges_ids[i]] = self._interface.set_mesh_edge(self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
-                                          edge_vertex_ids1[i], edge_vertex_ids2[i])
+            self._precice_edge_dict[edges_ids[i]] = self._interface.set_mesh_edge(
+                self._interface.get_mesh_id(self._config.get_coupling_mesh_name()),
+                edge_vertex_ids1[i], edge_vertex_ids2[i])
 
         # Configure mesh connectivity (triangles from edges) for 2D simulations
         if self._fenics_dims == 2:

--- a/fenicsprecice/fenicsprecice.py
+++ b/fenicsprecice/fenicsprecice.py
@@ -65,6 +65,7 @@ class Adapter:
         self._unowned_vertices = Vertices(VertexType.UNOWNED)
         self._fenics_vertices = Vertices(VertexType.FENICS)
         self._precice_vertex_ids = None  # initialized later
+        self._precice_edge_dict = dict()
 
         # read data related quantities (read data is read from preCICE and applied in FEniCS)
         self._read_function_type = None  # stores whether read function is scalar or vector valued
@@ -413,9 +414,6 @@ class Adapter:
         edge_vertex_ids1, edge_vertex_ids2, edges_ids = get_coupling_boundary_edges(function_space, coupling_subdomain,
                                                                          self._owned_vertices.get_global_ids(),
                                                                          id_mapping)
-
-        # Initialize preCICE edges dict
-        self._precice_edge_dict = {}
 
         for i in range(len(edge_vertex_ids1)):
             assert (edge_vertex_ids1[i] != edge_vertex_ids2[i])

--- a/tests/unit/test_adapter_core.py
+++ b/tests/unit/test_adapter_core.py
@@ -29,7 +29,7 @@ class TestAdapterCore(TestCase):
             if right_edge.inside(v.point(), True):
                 global_ids.append(v.global_index())
 
-        edge_vertex_ids1, edge_vertex_ids2 = get_coupling_boundary_edges(V, right_edge, global_ids, id_mapping)
+        edge_vertex_ids1, edge_vertex_ids2, _ = get_coupling_boundary_edges(V, right_edge, global_ids, id_mapping)
 
         self.assertEqual(len(edge_vertex_ids1), 10)
         self.assertEqual(len(edge_vertex_ids2), 10)


### PR DESCRIPTION
Added configuration of connectivity data for volume coupling: triangles from the coupling domain are added to the preCICE mesh.
It (seems to) works in serial & parallel, however the parallel version has "holes", as triangles made of owned+unowned vertices are discared:

![image](https://user-images.githubusercontent.com/84379125/170890527-4eb7ea9b-fbc5-4e97-a9e6-fc3476497dda.png)

This is however consistent with the current implementation, which does the same in surface coupling with edges.

Questions:
- Currently this is always done. Should it be a parameter, or should we rely on preCICE to ignore useless connectivity? THere are no checks for edges and I went for consistency first...
- There is an assertion that the mesh is made of triangles. Not ideal, but I'm open to suggestions for alternatives. How would it work with quads or in  3D ?
- Some parts of the code aren't very pythonic, I'm open to style suggestions!


Code for testing:

[fenics-adapter-test.tar.gz](https://github.com/precice/fenics-adapter/files/8794241/fenics-adapter-test.tar.gz)
