### PR TITLE
Update `CITATION.cff` to use `preferred-citation`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,45 +1,71 @@
-# YAML 1.2
----
-abstract: "The new software FEniCS-preCICE is a middle software layer, sitting in between the existing finite-element library FEniCS and the coupling library preCICE. The middle layer simplifies coupling (existing) FEniCS application codes to other simulation software via preCICE. To this end, FEniCS-preCICE converts between FEniCS and preCICE mesh and data structures, provides easy-to-use coupling conditions, and manages data checkpointing for implicit coupling. The new software is a library itself and follows a FEniCS-native style. Only a few lines of additional code are necessary to prepare a FEniCS application code for coupling. We illustrate the functionality of FEniCS-preCICE by two examples: a FEniCS heat conduction code coupled to OpenFOAM and a FEniCS linear elasticity code coupled to SU2. The results of both scenarios are compared with other simulation software showing good agreement."
-authors: 
-  -
-    affiliation: "Technical University of Munich"
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: FEniCS-preCICE
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Benjamin
     family-names: Rodenberg
-    given-names: Benjamin
-    orcid: "https://orcid.org/0000-0002-3116-0133"
-  -
-    affiliation: "University Stuttgart"
+    orcid: 'https://orcid.org/0000-0002-3116-0133'
+    affiliation: Technical University of Munich
+  - given-names: Ishaan
     family-names: Desai
-    given-names: Ishaan
-    orcid: "https://orcid.org/0000-0002-2552-7509"
-  -
-    family-names: Hertrich
+    orcid: 'https://orcid.org/0000-0002-2552-7509'
+    affiliation: University Stuttgart
+  - family-names: Hertrich
     given-names: Richard
-    orcid: "https://orcid.org/0000-0003-1722-2841"
-  -
-    affiliation: "University of Stuttgart"
-    family-names: Jaust
-    given-names: Alexander
-    orcid: "https://orcid.org/0000-0002-6082-105X"
-  -
-    affiliation: "University of Stuttgart"
-    family-names: Uekermann
-    given-names: Benjamin
-    orcid: "https://orcid.org/0000-0002-1314-9969"
-cff-version: "1.1.0"
-date-released: 2021-01-10
-keywords: 
-  - FEniCS
-  - "Fluid-Structure Interaction"
-  - "Conjugate Heat Transfer"
-  - Multiphysics
-  - "Coupled Problems"
-  - "Finite Element Method"
-  - preCICE
-license: "LGPL-3.0"
-message: "If you use this software, please cite it using these metadata."
-repository-code: "https://github.com/precice/fenics-adapter"
-title: "FEniCS-preCICE: Coupling FEniCS to other Simulation Software"
-version: 1.2.0
-doi: 10.1016/j.softx.2021.100807
-...
+    orcid: 'https://orcid.org/0000-0003-1722-2841'
+  - affiliation: University of Stuttgart
+    given-names: Jaust
+    family-names: Alexander
+    orcid: 'https://orcid.org/0000-0002-6082-105X'
+  - affiliation: University of Stuttgart
+    given-names: Uekermann
+    family-names: Benjamin
+    orcid: 'https://orcid.org/0000-0002-1314-9969'
+repository-code: 'https://github.com/precice/fenics-adapter'
+abstract: >-
+  preCICE-adapter for the open source computing platform
+  FEniCS.
+license: LGPL-3.0
+commit: ' 9aa3e22'
+version: 1.4.0
+date-released: '2022-09-22'
+preferred-citation:
+  title: "FEniCS-preCICE: Coupling FEniCS to other Simulation Software"
+  type: "article"
+  abstract: "The new software FEniCS-preCICE is a middle software layer, sitting in between the existing finite-element library FEniCS and the coupling library preCICE. The middle layer simplifies coupling (existing) FEniCS application codes to other simulation software via preCICE. To this end, FEniCS-preCICE converts between FEniCS and preCICE mesh and data structures, provides easy-to-use coupling conditions, and manages data checkpointing for implicit coupling. The new software is a library itself and follows a FEniCS-native style. Only a few lines of additional code are necessary to prepare a FEniCS application code for coupling. We illustrate the functionality of FEniCS-preCICE by two examples: a FEniCS heat conduction code coupled to OpenFOAM and a FEniCS linear elasticity code coupled to SU2. The results of both scenarios are compared with other simulation software showing good agreement."
+  authors: 
+    -
+      affiliation: "Technical University of Munich"
+      family-names: Rodenberg
+      given-names: Benjamin
+      orcid: "https://orcid.org/0000-0002-3116-0133"
+    -
+      affiliation: "University Stuttgart"
+      family-names: Desai
+      given-names: Ishaan
+      orcid: "https://orcid.org/0000-0002-2552-7509"
+    -
+      family-names: Hertrich
+      given-names: Richard
+      orcid: "https://orcid.org/0000-0003-1722-2841"
+    -
+      affiliation: "University of Stuttgart"
+      family-names: Jaust
+      given-names: Alexander
+      orcid: "https://orcid.org/0000-0002-6082-105X"
+    -
+      affiliation: "University of Stuttgart"
+      family-names: Uekermann
+      given-names: Benjamin
+      orcid: "https://orcid.org/0000-0002-1314-9969"
+  doi: 10.1016/j.softx.2021.100807
+  journal: "SoftwareX"
+  volume: 16
+  pages: 100807
+  year: 2021

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@
 cff-version: 1.2.0
 title: FEniCS-preCICE
 message: >-
-  If you use this software, please cite it using the
-  metadata from this file.
+  If you use this software, please cite it using the metadata from this file. When using or referring to preCICE in
+  academic publications, please follow the [citation guidelines](https://precice.org/fundamentals-literature-guide.html). 
 type: software
 authors:
   - given-names: Benjamin

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -38,29 +38,23 @@ date-released: '2022-09-22'
 preferred-citation:
   title: "FEniCS-preCICE: Coupling FEniCS to other Simulation Software"
   type: "article"
-  abstract: "The new software FEniCS-preCICE is a middle software layer, sitting in between the existing finite-element library FEniCS and the coupling library preCICE. The middle layer simplifies coupling (existing) FEniCS application codes to other simulation software via preCICE. To this end, FEniCS-preCICE converts between FEniCS and preCICE mesh and data structures, provides easy-to-use coupling conditions, and manages data checkpointing for implicit coupling. The new software is a library itself and follows a FEniCS-native style. Only a few lines of additional code are necessary to prepare a FEniCS application code for coupling. We illustrate the functionality of FEniCS-preCICE by two examples: a FEniCS heat conduction code coupled to OpenFOAM and a FEniCS linear elasticity code coupled to SU2. The results of both scenarios are compared with other simulation software showing good agreement."
   authors: 
-    -
-      affiliation: "Technical University of Munich"
+    - affiliation: "Technical University of Munich"
       family-names: Rodenberg
       given-names: Benjamin
       orcid: "https://orcid.org/0000-0002-3116-0133"
-    -
-      affiliation: "University Stuttgart"
+    - affiliation: "University Stuttgart"
       family-names: Desai
       given-names: Ishaan
       orcid: "https://orcid.org/0000-0002-2552-7509"
-    -
-      family-names: Hertrich
+    - family-names: Hertrich
       given-names: Richard
       orcid: "https://orcid.org/0000-0003-1722-2841"
-    -
-      affiliation: "University of Stuttgart"
+    - affiliation: "University of Stuttgart"
       family-names: Jaust
       given-names: Alexander
       orcid: "https://orcid.org/0000-0002-6082-105X"
-    -
-      affiliation: "University of Stuttgart"
+    - affiliation: "University of Stuttgart"
       family-names: Uekermann
       given-names: Benjamin
       orcid: "https://orcid.org/0000-0002-1314-9969"

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -9,7 +9,7 @@ Before starting this process make sure to check that all relevant changes are in
 3. Bump the version in the following places:
 
     a) Before merging the PR, make sure to bump the version in `CHANGELOG.md` on `fenics-adapter-vX.X.X`
-    b) Update the version in `CITATION.cff` and update the release date
+    b) Update the version in `CITATION.cff` and update the release date 
     c) There is no need to bump the version anywhere else, since we use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version everywhere else.
 
 5. [Draft a New Release](https://github.com/precice/fenics-adapter/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v1.0.0` or `v1.0.0rc1`, compare to [existing tags](https://github.com/precice/fenics-adapter/tags)). Use `@target:master`. Release title is also the version number (i.e. `v1.0.0` or `v1.0.0rc1`, compare to [existing releases](https://github.com/precice/fenics-adapter/tags)).

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -8,16 +8,17 @@ Before starting this process make sure to check that all relevant changes are in
 
 3. Bump the version in the following places:
 
-    a) Before merging the PR, make sure to bump the version in `CHANGELOG.md` on `fenics-adapter-vX.X.X`  
-    b) There is no need to bump the version anywhere else, since we use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version everywhere else.
+    a) Before merging the PR, make sure to bump the version in `CHANGELOG.md` on `fenics-adapter-vX.X.X`
+    b) Update the version in `CITATION.cff` and update the release date
+    c) There is no need to bump the version anywhere else, since we use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version everywhere else.
 
-4. [Draft a New Release](https://github.com/precice/fenics-adapter/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v1.0.0` or `v1.0.0rc1`, compare to [existing tags](https://github.com/precice/fenics-adapter/tags)). Use `@target:master`. Release title is also the version number (i.e. `v1.0.0` or `v1.0.0rc1`, compare to [existing releases](https://github.com/precice/fenics-adapter/tags)).
+5. [Draft a New Release](https://github.com/precice/fenics-adapter/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v1.0.0` or `v1.0.0rc1`, compare to [existing tags](https://github.com/precice/fenics-adapter/tags)). Use `@target:master`. Release title is also the version number (i.e. `v1.0.0` or `v1.0.0rc1`, compare to [existing releases](https://github.com/precice/fenics-adapter/tags)).
 *Note:* If it is a pre-release then the option *This is a pre-release* needs to be selected at the bottom of the page. Use `@target:fenics-adapter-vX.X.X` for a pre-release, since we will never merge a pre-release into master.
 
     a) If a pre-release is made: Directly hit the "Publish release" button in your Release Draft. Now you can check the artifacts (e.g. release on [PyPI](https://pypi.org/project/fenicsprecice/#history)) of the release. *Note:* As soon as a new tag is created github actions will take care of deploying the new version on PyPI using [this workflow](https://github.com/precice/fenics-adapter/actions?query=workflow%3A%22Upload+Python+Package%22).
 
     b) If this is a "real" release: As soon as one approving review is made, merge the release PR (`fenics-adapter-vX.X.X`) into `master`.
 
-5. Merge `master` into `develop` for synchronization of `develop`.
+6. Merge `master` into `develop` for synchronization of `develop`.
 
-6. If everything is in order up to this point then the new version can be released by hitting the "Publish release" button in your Release Draft.
+7. If everything is in order up to this point then the new version can be released by hitting the "Publish release" button in your Release Draft.

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -8,8 +8,10 @@ Before starting this process make sure to check that all relevant changes are in
 
 3. Bump the version in the following places:
 
-    a) Before merging the PR, make sure to bump the version in `CHANGELOG.md` on `fenics-adapter-vX.X.X`
-    b) Update the version in `CITATION.cff` and update the release date 
+    a) Before merging the PR, make sure to bump the version in `CHANGELOG.md` on `fenics-adapter-vX.X.X`.
+   
+    b) Update the version in `CITATION.cff` and update the release date.
+
     c) There is no need to bump the version anywhere else, since we use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version everywhere else.
 
 5. [Draft a New Release](https://github.com/precice/fenics-adapter/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v1.0.0` or `v1.0.0rc1`, compare to [existing tags](https://github.com/precice/fenics-adapter/tags)). Use `@target:master`. Release title is also the version number (i.e. `v1.0.0` or `v1.0.0rc1`, compare to [existing releases](https://github.com/precice/fenics-adapter/tags)).

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -2,25 +2,25 @@
 
 Before starting this process make sure to check that all relevant changes are included in the `CHANGELOG.md`. The developer who is releasing a new version of FEniCS-preCICE adapter is expected to follow this workflow:
 
-1. If it does not already exist, create a release branch with the version number of the planned release. Use develop as base for the branch. `git checkout develop`; `git checkout -b fenics-adapter-vX.X.X`. Perform the following steps only on the release branch, if not indicated differently.  
+1. If it does not already exist, create a release branch with the version number of the planned release. Use develop as base for the branch. `git checkout develop`; `git checkout -b fenics-adapter-vX.X.X`. Perform the following steps only on the release branch, if not indicated differently.
 
 2. [Open a Pull Request from the branch `fenics-adapter-vX.X.X` to `master`](https://github.com/precice/fenics-adapter/compare) named after the version (i.e. `Release v1.0.0`) and briefly describe the new features of the release in the PR description.
 
 3. Bump the version in the following places:
 
     a) Before merging the PR, make sure to bump the version in `CHANGELOG.md` on `fenics-adapter-vX.X.X`.
-   
+
     b) Update the version in `CITATION.cff` and update the release date.
 
     c) There is no need to bump the version anywhere else, since we use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version everywhere else.
 
-5. [Draft a New Release](https://github.com/precice/fenics-adapter/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v1.0.0` or `v1.0.0rc1`, compare to [existing tags](https://github.com/precice/fenics-adapter/tags)). Use `@target:master`. Release title is also the version number (i.e. `v1.0.0` or `v1.0.0rc1`, compare to [existing releases](https://github.com/precice/fenics-adapter/tags)).
+4. [Draft a New Release](https://github.com/precice/fenics-adapter/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v1.0.0` or `v1.0.0rc1`, compare to [existing tags](https://github.com/precice/fenics-adapter/tags)). Use `@target:master`. Release title is also the version number (i.e. `v1.0.0` or `v1.0.0rc1`, compare to [existing releases](https://github.com/precice/fenics-adapter/tags)).
 *Note:* If it is a pre-release then the option *This is a pre-release* needs to be selected at the bottom of the page. Use `@target:fenics-adapter-vX.X.X` for a pre-release, since we will never merge a pre-release into master.
 
     a) If a pre-release is made: Directly hit the "Publish release" button in your Release Draft. Now you can check the artifacts (e.g. release on [PyPI](https://pypi.org/project/fenicsprecice/#history)) of the release. *Note:* As soon as a new tag is created github actions will take care of deploying the new version on PyPI using [this workflow](https://github.com/precice/fenics-adapter/actions?query=workflow%3A%22Upload+Python+Package%22).
 
     b) If this is a "real" release: As soon as one approving review is made, merge the release PR (`fenics-adapter-vX.X.X`) into `master`.
 
-6. Merge `master` into `develop` for synchronization of `develop`.
+5. Merge `master` into `develop` for synchronization of `develop`.
 
-7. If everything is in order up to this point then the new version can be released by hitting the "Publish release" button in your Release Draft.
+6. If everything is in order up to this point then the new version can be released by hitting the "Publish release" button in your Release Draft.


### PR DESCRIPTION
* Use `preferred-citation` to point to the FEniCS-preCICE paper
* Provide citation information about software on top level.
  * Open for discussion: Might be extended with other/future contributors that did not author the paper. Important: We need a proper and simple policy here. See also https://github.com/precice/fenics-adapter/graphs/contributors
  * Add a DOI? We could point to the preCICE distribution, but this is actually a superset of FEniCS-preCICE and the policy w.r.t. authorship is also independent. I would rather keep things separate and not provide a DOI. If we really want a DOI, we can still release on zenodo. This looks to me like the go-to-solution suggested by the CFF developers: https://citation-file-format.github.io/
