### PR TITLE
Build `latest` docker container from master not `develop` branch

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,11 +24,15 @@ jobs:
       - name: Set branch name for manual triggering
         if: github.event_name == 'workflow_dispatch'
         shell: bash
-        run: echo "branch=${{ inputs.branch }}" >> $GITHUB_ENV    
+        run: | 
+          echo "ADAPTER_REF=${{ inputs.branch }}" >> $GITHUB_ENV
+          echo "PYTHON_REF=latest" >> $GITHUB_ENV       
       - name: Set branch name for on pull triggering
         if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
         shell: bash
-        run: echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV    
+        run: |
+          echo "ADAPTER_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "PYTHON_REF=develop" >> $GITHUB_ENV          
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -40,19 +44,21 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push latest Dockerfile
         uses: docker/build-push-action@v2
-        if: ${{ env.branch }} == 'master'
+        if: ${{ env.ADAPTER_REF }} == 'master'
         with:
           push: true
           file: "./tools/releasing/packaging/docker/Dockerfile"
           tags: ${{ env.docker_username }}/fenics-adapter:latest
           build-args: |
-            branch=${{ env.branch }}
+            FENICS_ADAPTER_REF=${{ env.ADAPTER_REF }}
+            PYTHON_BINDINGS_REF=${{ env.PYTHON_REF }}
       - name: Build and push develop Dockerfile
         uses: docker/build-push-action@v2
-        if: ${{ env.branch }} != 'master'
+        if: ${{ env.ADAPTER_REF }} != 'master'
         with:
           push: true
           file: "./tools/releasing/packaging/docker/Dockerfile"
           tags: ${{ env.docker_username }}/fenics-adapter:${{ env.branch }}
           build-args: |
-            branch=${{ env.branch }}
+            FENICS_ADAPTER_REF=${{ env.ADAPTER_REF }}
+            PYTHON_BINDINGS_REF=${{ env.PYTHON_REF }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,11 +22,11 @@ jobs:
         docker_username: precice
     steps:
       - name: Set branch name for manual triggering
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: echo "branch=${{ inputs.branch }}" >> $GITHUB_ENV    
-      - name: Set branch name for manual triggering
-        if: github.event_name != 'pull_request'
+      - name: Set branch name for on pull triggering
+        if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
         shell: bash
         run: echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV    
       - name: Checkout Repository

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,7 +1,14 @@
 name: Update docker image
 
 on:
-  workflow_dispatch:      # Trigger by hand from the UI
+  workflow_dispatch: # Trigger by hand from the UI
+    inputs:
+      branch:
+        type: choice
+        description: branch to build the container from
+        options:
+          - develop
+          - master     
   push:
     branches:
       - develop
@@ -14,10 +21,14 @@ jobs:
     env:
         docker_username: precice
     steps:
-      - name: Get branch name
+      - name: Set branch name for manual triggering
         if: github.event_name != 'pull_request'
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV    
+        run: echo "branch=${{ inputs.branch }}" >> $GITHUB_ENV    
+      - name: Set branch name for manual triggering
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV    
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,14 +25,24 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: | 
-          echo "ADAPTER_REF=${{ inputs.branch }}" >> $GITHUB_ENV
-          echo "PYTHON_REF=latest" >> $GITHUB_ENV       
+          echo "ADAPTER_REF=${{ inputs.branch }}" >> $GITHUB_ENV 
       - name: Set branch name for on pull triggering
         if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
         shell: bash
         run: |
           echo "ADAPTER_REF=${{ github.ref_name }}" >> $GITHUB_ENV
-          echo "PYTHON_REF=develop" >> $GITHUB_ENV          
+      - name: Set PYTHON_BINDINGS_REF and the TAG depending on branch
+        shell: bash
+        run: |
+          if [[ '${{ env.ADAPTER_REF }}' == 'master' ]]; then
+              echo "PYTHON_BINDINGS_REF=latest" >> "$GITHUB_ENV"
+              echo "TAG=latest" >> "$GITHUB_ENV"
+              echo "Building TAG: latest"
+          else
+              echo "PYTHON_BINDINGS_REF=${{ env.ADAPTER_REF }}" >> "$GITHUB_ENV"
+              echo "TAG=${{ env.ADAPTER_REF }}" >> "$GITHUB_ENV"
+              echo "Building TAG: ${{ env.ADAPTER_REF }}"
+          fi   
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -42,23 +52,12 @@ jobs:
         with:
           username: ${{ env.docker_username }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push latest Dockerfile
+      - name: Build and push Dockerfile
         uses: docker/build-push-action@v2
-        if: ${{ env.ADAPTER_REF }} == 'master'
         with:
           push: true
           file: "./tools/releasing/packaging/docker/Dockerfile"
-          tags: ${{ env.docker_username }}/fenics-adapter:latest
+          tags: ${{ env.docker_username }}/fenics-adapter:${{ env.TAG }}
           build-args: |
             FENICS_ADAPTER_REF=${{ env.ADAPTER_REF }}
-            PYTHON_BINDINGS_REF=${{ env.PYTHON_REF }}
-      - name: Build and push develop Dockerfile
-        uses: docker/build-push-action@v2
-        if: ${{ env.ADAPTER_REF }} != 'master'
-        with:
-          push: true
-          file: "./tools/releasing/packaging/docker/Dockerfile"
-          tags: ${{ env.docker_username }}/fenics-adapter:${{ env.branch }}
-          build-args: |
-            FENICS_ADAPTER_REF=${{ env.ADAPTER_REF }}
-            PYTHON_BINDINGS_REF=${{ env.PYTHON_REF }}
+            PYTHON_BINDINGS_REF=${{ env.PYTHON_BINDINGS_REF }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+      - master
 
 jobs:
   build-and-release-docker-image:
@@ -26,11 +27,21 @@ jobs:
         with:
           username: ${{ env.docker_username }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push Dockerfile
+      - name: Build and push latest Dockerfile
         uses: docker/build-push-action@v2
+        if: ${{ env.branch }} == 'master'
         with:
           push: true
           file: "./tools/releasing/packaging/docker/Dockerfile"
-          tags: ${{ env.docker_username }}/fenics-adapter:${{ env.branch }},${{ env.docker_username }}/fenics-adapter:latest
+          tags: ${{ env.docker_username }}/fenics-adapter:latest
+          build-args: |
+            branch=${{ env.branch }}
+      - name: Build and push develop Dockerfile
+        uses: docker/build-push-action@v2
+        if: ${{ env.branch }} != 'master'
+        with:
+          push: true
+          file: "./tools/releasing/packaging/docker/Dockerfile"
+          tags: ${{ env.docker_username }}/fenics-adapter:${{ env.branch }}
           build-args: |
             branch=${{ env.branch }}

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to build a ubuntu image containing the installed Debian package of a release 
-ARG branch=develop
-ARG from=precice/python-bindings:${branch}
+ARG PYTHON_BINDINGS_REF=develop
+ARG from=precice/python-bindings:${PYTHON_BINDINGS_REF}
 FROM $from
 
 USER root
@@ -17,7 +17,7 @@ RUN python3 -m pip install --user --upgrade pip
 
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
-ARG branch=develop
+ARG FENICS_ADAPTER_REF=develop
 
 # Building fenics-adapter
-RUN python3 -m pip install --user git+https://github.com/precice/fenics-adapter.git@$branch
+RUN python3 -m pip install --user git+https://github.com/precice/fenics-adapter.git@$FENICS_ADAPTER_REF


### PR DESCRIPTION
Should fix #160 
Here a similar idea to the python-bindings applies: 
I Made the Workflow a bit more usable via the manual dispatch and also split up `latest` and `develop` tags accordingly. 

Additionally the Dockerfile is more in line with the current approach to Dockerfiles used in the Systemtestsv2