### PR TITLE
Use `copy(deepcopy=true)` for checkpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-* Use `copy(deepcopy=True)` when checkpointing to make checkpointing more user-friendly and secure. [#172](https://github.com/precice/fenics-adapter/pull/172)
+* Use `copy(deepcopy=True)` when checkpointing to make checkpointing more user-friendly and secure. IMPORTANT: might increase runtime, please open an issue if you face serious problems. [#172](https://github.com/precice/fenics-adapter/pull/172)
 * Add unit tests for checkpointing. [#173](https://github.com/precice/fenics-adapter/pull/173)
 
 ## 2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+* Use `copy(deepcopy=True)` when checkpointing to make checkpointing more user-friendly and secure. [#172](https://github.com/precice/fenics-adapter/pull/172)
 * Add unit tests for checkpointing. [#173](https://github.com/precice/fenics-adapter/pull/173)
 
 ## 2.1.0

--- a/fenicsprecice/solverstate.py
+++ b/fenicsprecice/solverstate.py
@@ -13,9 +13,9 @@ class SolverState:
             Iteration number.
         """
         try:
-            self.payload = payload.copy()
-        except AttributeError:  # if .copy() does not exist, it probably is a list
-            self.payload = [item.copy() for item in payload]
+            self.payload = payload.copy(deepcopy=True)
+        except (AttributeError, TypeError):  # AttributeError, if .copy() does not exist; TypeError, if .copy(deepcopy) does not exist. -> Probably a list
+            self.payload = [item.copy(deepcopy=True) for item in payload]
 
         self.t = t
         self.n = n
@@ -34,9 +34,9 @@ class SolverState:
             Iteration number.
         """
         try:
-            return self.payload.copy(), self.t, self.n
-        except AttributeError:  # if .copy() does not exist, it probably is a list
-            return [item.copy() for item in self.payload], self.t, self.n
+            return self.payload.copy(deepcopy=True), self.t, self.n
+        except (AttributeError, TypeError):  # AttributeError, if .copy() does not exist; TypeError, if .copy(deepcopy) does not exist. -> Probably a list
+            return [item.copy(deepcopy=True) for item in self.payload], self.t, self.n
 
     def print_state(self):
         payload, t, n = self.get_state()

--- a/tests/integration/test_fenicsprecice.py
+++ b/tests/integration/test_fenicsprecice.py
@@ -25,7 +25,11 @@ class MockedArray:
         """
         self.value = new_value.value
 
-    def copy(self):
+    def copy(self, deepcopy=False):
+        """
+        mock of dolfin.Function.copy
+        :param deepcopy: has no effect but we need to provide it to avoid throwing TypeError if copy(deepcopy=True) is called
+        """
         returned_array = MockedArray()
         returned_array.value = self.value
         return returned_array


### PR DESCRIPTION
There seems to be a bug when using checkpointing. I stumbled across this with subcycling:

* Perpendicular flap case with FEniCS and OpenFOAM as given in https://github.com/precice/tutorials/commit/c20ed5bc4705e7ebdbb8b26d8fe31ad63f2d3810. Use subcycling in `solid.py` by setting `fenics_dt = precice_dt / 10`. Here, OpenFOAM runs into an exception after some time. The vtk files also start to obviously look faulty after some time.
* Perpendicular flap case with FEniCS and Fake fluid as given in https://github.com/precice/tutorials/commit/c20ed5bc4705e7ebdbb8b26d8fe31ad63f2d3810. Use subcycling like above. Simulation runs through, but vtk results are incorrect.

Looking at the value of `u_n` in any of these cases shows that we do not correctly load the checkpoint we originally stored. I assume there is some unintended pointer-magic happening. I used the following debugging statements in `solid.py` to sample the solution at the tip of the flap:

```
if precice.requires_writing_checkpoint():  # write checkpoint
    print(f"Store checkpoint: {(u_n(0,H), v_n(0,H), a_n(0,H)),t,n}")
...
if precice.requires_reading_checkpoint():  # roll back to checkpoint
    print(f"Read checkpoint: {(u_cp(0,H), v_cp(0,H), a_cp(0,H)),t_cp,n_cp}")
    print(f"Overwrites: {(u_n(0,H), v_n(0,H), a_n(0,H)),t,n}")
    print(f"Ignores: {u_np1(0,H)}")
    ...
else:
    print(f"u_n: {(u_n(0,H), v_n(0,H), a_n(0,H)),t,n}")
...
```

The fixes applied here seem to avoid the error.

There are still some todos:

* Test this to make sure we don't get a similar error again.
* Understand performance implications. I have the impression that creating a deep-copy slows down the process. Would be nice to find a more efficient way, but the primary goal is to fix the bug.