### PR TITLE
Tests checking implementation of checkpointing/SolverState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # FEniCS-preCICE adapter changelog
 
+## latest
+
+* Add unit tests for checkpointing. [#173](https://github.com/precice/fenics-adapter/pull/173)
+
 ## 2.1.0
 
 * Additionally support checkpoints being provided as a list or tuple (of FEniCS Functions). [#170](https://github.com/precice/fenics-adapter/pull/170)

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock
 from unittest import TestCase
 from fenics import FunctionSpace, UnitSquareMesh, Expression, interpolate
-import random as rnd
 from fenicsprecice.solverstate import SolverState
 
 

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -39,25 +39,26 @@ class TestCheckpointing(TestCase):
         size = 5
         mesh = UnitSquareMesh(size,size)
         V = FunctionSpace(mesh, 'P', 2)
-        dummy_value = 1
-        E = Expression("t", t=dummy_value, degree=2)
+        ref_value = 1
+        E = Expression("t", t=ref_value, degree=2)
         u = interpolate(E, V)
 
         # "write checkpoint"
-        sstate = SolverState(u, dummy_value, n)
+        sstate = SolverState(u, ref_value, n)
 
         # modify state of u
-        u.vector()[:] = dummy_value + 2
+        dummy_value = ref_value + 2
+        u.vector()[:] = dummy_value
 
         # "read checkpoint"
         u_cp, _, _ = sstate.get_state()
 
         #check values
         #function should be the same everywhere
-        #(so the vector values should all be dummy_value=1)
+        #(so the vector values should all be ref_value)
         vec_u_cp = u_cp.vector()
         for i in range(size*size):
-            self.assertAlmostEqual(dummy_value, vec_u_cp[i])
+            self.assertAlmostEqual(ref_value, vec_u_cp[i])
     
 
     def test_solverstate_modification_assign(self):
@@ -69,16 +70,17 @@ class TestCheckpointing(TestCase):
         size = 5
         mesh = UnitSquareMesh(size,size)
         V = FunctionSpace(mesh, 'P', 2)
-        dummy_value = 1
-        E = Expression("t", t=dummy_value, degree=2)
+        ref_value = 1
+        E = Expression("t", t=ref_value, degree=2)
         u = interpolate(E, V)
 
         # "write checkpoint"
-        sstate = SolverState(u, dummy_value, n)
+        sstate = SolverState(u, ref_value, n)
 
         # modify state of u
         # "compute" new solution
-        E.t += 2
+        dummy_value = ref_value + 2
+        E.t = dummy_value
         u2 = interpolate(E,V)
         u.assign(u2)
 
@@ -87,7 +89,7 @@ class TestCheckpointing(TestCase):
 
         #check values
         #function should be the same everywhere
-        #(so the vector values should all be dummy_value=1)
+        #(so the vector values should all be ref_value)
         vec_u_cp = u_cp.vector()
         for i in range(size*size):
-            self.assertAlmostEqual(dummy_value, vec_u_cp[i])
+            self.assertAlmostEqual(ref_value, vec_u_cp[i])

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -1,0 +1,94 @@
+from unittest.mock import MagicMock
+from unittest import TestCase
+from fenics import FunctionSpace, UnitSquareMesh, Expression, interpolate
+import random as rnd
+from fenicsprecice.solverstate import SolverState
+
+
+class TestCheckpointing(TestCase):
+    def test_solverstate_basic(self):
+        """
+        Check if correct values are read from the checkpoint, while the state of the object that is copied is not changed
+        """
+        time = 0.5
+        iteration = 1
+        size = 5
+        mesh = UnitSquareMesh(size,size)
+        V = FunctionSpace(mesh, 'P', 2)
+        E = Expression("t", t=time, degree=2)
+        u = interpolate(E, V)
+
+        # "write checkpoint"
+        sstate = SolverState(u, time, iteration)
+        # "read checkpoint"
+        u_cp, t_cp, n_cp = sstate.get_state()
+
+        #check values
+        self.assertEqual(t_cp, time)
+        self.assertEqual(iteration, n_cp)
+        #function should be the same everywhere (-> check vector values of the function)
+        vec_u = u.vector()
+        vec_u_cp = u_cp.vector()
+        for i in range(size*size):
+            self.assertAlmostEqual(vec_u[i], vec_u_cp[i])
+
+    def test_solverstate_modification_vector(self):
+        """
+        Check if correct values are read from the checkpoint, if the dof vector of the dolfin functions are changed directly 
+        """
+        time = 0.5
+        iteration = 1
+        size = 5
+        mesh = UnitSquareMesh(size,size)
+        V = FunctionSpace(mesh, 'P', 2)
+        E = Expression("t", t=time, degree=2)
+        u = interpolate(E, V)
+
+        # "write checkpoint"
+        sstate = SolverState(u, time, iteration)
+
+        # modify state of u
+        u.vector()[:] = time + 2
+
+        # "read checkpoint"
+        u_cp, _, _ = sstate.get_state()
+
+        #check values
+        #function should be the same everywhere
+        #(so the vector values should all be time=0.5)
+        vec_u_cp = u_cp.vector()
+        for i in range(size*size):
+            self.assertAlmostEqual(time, vec_u_cp[i])
+    
+
+    def test_solverstate_modification_assign(self):
+        """
+        Check if correct values are read from the checkpoint, if the dof of the dolfin functions are changed with the assign function
+        and not directly via the dof vector
+        """
+        time = 0.5
+        iteration = 1
+        size = 5
+        mesh = UnitSquareMesh(size,size)
+        V = FunctionSpace(mesh, 'P', 2)
+        E = Expression("t", t=time, degree=2)
+        u = interpolate(E, V)
+
+        # "write checkpoint"
+        sstate = SolverState(u, time, iteration)
+
+        # modify state of u
+        # "compute" new solution
+        E.t += 2
+        u2 = interpolate(E,V)
+        u.assign(u2)
+
+        # "read checkpoint"
+        u_cp, _, _ = sstate.get_state()
+
+        #check values
+        #function should be the same everywhere
+        #(so the vector values should all be time=0.5)
+        vec_u_cp = u_cp.vector()
+        for i in range(size*size):
+            self.assertAlmostEqual(time, vec_u_cp[i])

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -34,6 +34,8 @@ class TestCheckpointing(TestCase):
     def test_solverstate_modification_vector(self):
         """
         Check if correct values are read from the checkpoint, if the dof vector of the dolfin functions are changed directly 
+
+        Motivation for this test: Related to https://github.com/precice/fenics-adapter/pull/172 and https://github.com/precice/tutorials/pull/554
         """
         n = 1
         size = 5

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -9,22 +9,22 @@ class TestCheckpointing(TestCase):
         """
         Check if correct values are read from the checkpoint, while the state of the object that is copied is not changed
         """
-        time = 0.5
-        iteration = 1
+        n = 1
         size = 5
         mesh = UnitSquareMesh(size,size)
         V = FunctionSpace(mesh, 'P', 2)
-        E = Expression("t", t=time, degree=2)
+        dummy_value = 1
+        E = Expression("t", t=dummy_value, degree=2)
         u = interpolate(E, V)
 
         # "write checkpoint"
-        sstate = SolverState(u, time, iteration)
+        sstate = SolverState(u, dummy_value, n)
         # "read checkpoint"
         u_cp, t_cp, n_cp = sstate.get_state()
 
         #check values
-        self.assertEqual(t_cp, time)
-        self.assertEqual(iteration, n_cp)
+        self.assertEqual(t_cp, dummy_value)
+        self.assertEqual(n, n_cp)
         #function should be the same everywhere (-> check vector values of the function)
         vec_u = u.vector()
         vec_u_cp = u_cp.vector()
@@ -35,29 +35,29 @@ class TestCheckpointing(TestCase):
         """
         Check if correct values are read from the checkpoint, if the dof vector of the dolfin functions are changed directly 
         """
-        time = 0.5
-        iteration = 1
+        n = 1
         size = 5
         mesh = UnitSquareMesh(size,size)
         V = FunctionSpace(mesh, 'P', 2)
-        E = Expression("t", t=time, degree=2)
+        dummy_value = 1
+        E = Expression("t", t=dummy_value, degree=2)
         u = interpolate(E, V)
 
         # "write checkpoint"
-        sstate = SolverState(u, time, iteration)
+        sstate = SolverState(u, dummy_value, n)
 
         # modify state of u
-        u.vector()[:] = time + 2
+        u.vector()[:] = dummy_value + 2
 
         # "read checkpoint"
         u_cp, _, _ = sstate.get_state()
 
         #check values
         #function should be the same everywhere
-        #(so the vector values should all be time=0.5)
+        #(so the vector values should all be dummy_value=1)
         vec_u_cp = u_cp.vector()
         for i in range(size*size):
-            self.assertAlmostEqual(time, vec_u_cp[i])
+            self.assertAlmostEqual(dummy_value, vec_u_cp[i])
     
 
     def test_solverstate_modification_assign(self):
@@ -65,16 +65,16 @@ class TestCheckpointing(TestCase):
         Check if correct values are read from the checkpoint, if the dof of the dolfin functions are changed with the assign function
         and not directly via the dof vector
         """
-        time = 0.5
-        iteration = 1
+        n = 1
         size = 5
         mesh = UnitSquareMesh(size,size)
         V = FunctionSpace(mesh, 'P', 2)
-        E = Expression("t", t=time, degree=2)
+        dummy_value = 1
+        E = Expression("t", t=dummy_value, degree=2)
         u = interpolate(E, V)
 
         # "write checkpoint"
-        sstate = SolverState(u, time, iteration)
+        sstate = SolverState(u, dummy_value, n)
 
         # modify state of u
         # "compute" new solution
@@ -87,7 +87,7 @@ class TestCheckpointing(TestCase):
 
         #check values
         #function should be the same everywhere
-        #(so the vector values should all be time=0.5)
+        #(so the vector values should all be dummy_value=1)
         vec_u_cp = u_cp.vector()
         for i in range(size*size):
-            self.assertAlmostEqual(time, vec_u_cp[i])
+            self.assertAlmostEqual(dummy_value, vec_u_cp[i])


### PR DESCRIPTION
These tests are written in context of Pull Request https://github.com/precice/fenics-adapter/pull/172
Since the core functionality of the checkpointing is implemented in the SolverState class, the tests are actually testing only this class. 
This commit consists of three different tests:
1. Write checkpoint & directly load it (just for the sake of completeness)
2. Write checkpoint of a function, then modify the dof vector of the dolfin function by directly accessing it via `vector()`. After that, load the checkpoint.
3. Write checkpoint of a function, then modify the this dolfin function via `assign()`. After that, load the checkpoint.