### PR TITLE
Use `benjaminrodenberg/fenics` for CI stage "Build and Test"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pipx install setuptools wheel twine
+          pip3 install --break-system-packages setuptools wheel twine
       - name: Build distribution
         run:  python3 setup.py sdist
   test:
@@ -37,7 +37,7 @@ jobs:
           mkdir -p precice
           echo "from setuptools import setup" >> precice/setup.py
           echo "setup(name='pyprecice', version='3.0.0.0')" >> precice/setup.py
-          pipx install ./precice/
+          pip3 install --break-system-packages ./precice/
       - name: Run unit tests
         run:  python3 setup.py test -s tests.unit
       - name: Run integration tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
   test:
     name: Run mock unit tests
     runs-on: ubuntu-latest
-    container: quay.io/fenicsproject/stable:current
+    container: benjaminrodenberg/fenics
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2      

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install --user setuptools wheel twine
       - name: Build distribution
         run:  python3 setup.py sdist
   test:
@@ -37,7 +37,7 @@ jobs:
           mkdir -p precice
           echo "from setuptools import setup" >> precice/setup.py
           echo "setup(name='pyprecice', version='3.0.0.0')" >> precice/setup.py
-          python3 -m pip install ./precice/
+          python3 -m pip install --user ./precice/
       - name: Run unit tests
         run:  python3 setup.py test -s tests.unit
       - name: Run integration tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --user setuptools wheel twine
+          pipx install setuptools wheel twine
       - name: Build distribution
         run:  python3 setup.py sdist
   test:
@@ -37,7 +37,7 @@ jobs:
           mkdir -p precice
           echo "from setuptools import setup" >> precice/setup.py
           echo "setup(name='pyprecice', version='3.0.0.0')" >> precice/setup.py
-          python3 -m pip install --user ./precice/
+          pipx install ./precice/
       - name: Run unit tests
         run:  python3 setup.py test -s tests.unit
       - name: Run integration tests

--- a/tools/testing/docker/Dockerfile
+++ b/tools/testing/docker/Dockerfile
@@ -1,0 +1,14 @@
+# Dockerfile to build a ubuntu image containing the installed Debian package of a release 
+FROM ubuntu:24.04
+
+# Add the precice user to run test with mpi
+RUN useradd -m -s /bin/bash precice
+ENV PRECICE_USER=precice
+
+# Installing necessary dependencies
+RUN apt-get -qq update && \
+    apt-get -qq install software-properties-common && \
+    add-apt-repository -y ppa:fenics-packages/fenics && \
+    apt-get -qq update && \
+    apt-get -qq install --no-install-recommends fenics && \
+    rm -rf /var/lib/apt/lists/*

--- a/tools/testing/docker/Dockerfile
+++ b/tools/testing/docker/Dockerfile
@@ -10,5 +10,5 @@ RUN apt-get -qq update && \
     apt-get -qq install software-properties-common && \
     add-apt-repository -y ppa:fenics-packages/fenics && \
     apt-get -qq update && \
-    apt-get -qq install --no-install-recommends fenics && \
+    apt-get -qq install --no-install-recommends fenics python3-pip && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The image `quay.io/fenicsproject/stable:current` triggers the following error in our tests: 
```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/fenicsproject/stable:current to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```
I, therefore, created my own image based on a fenics installation with `apt`.