### PR TITLE
Modify `setup.py` to avoid crash due to version 4.0.0 of `mpi4py` during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use `copy(deepcopy=True)` when checkpointing to make checkpointing more user-friendly and secure. IMPORTANT: might increase runtime, please open an issue if you face serious problems. [#172](https://github.com/precice/fenics-adapter/pull/172)
 * Add unit tests for checkpointing. [#173](https://github.com/precice/fenics-adapter/pull/173)
+* Add required version of `mpi4py` to `<4` to avoid crash during installation. [#181](https://github.com/precice/fenics-adapter/pull/181)
 
 ## 2.1.0
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(name='fenicsprecice',
       author_email='info@precice.org',
       license='LGPL-3.0',
       packages=['fenicsprecice'],
-      setup_requires=['mpi4py<4'],
       install_requires=['pyprecice>=3.0.0.0', 'scipy', 'numpy>=1.13.3, <2', 'mpi4py<4'],
       test_suite='tests',
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,6 @@ if sys.version_info[1] == 6 and sys.version_info[2] == 9:
                   "when running the tests (see https://github.com/precice/fenics-adapter/pull/61). If you want to "
                   "run the tests, please install a different Python version.")
 
-try:
-    from fenics import *
-except ModuleNotFoundError:
-    warnings.warn("No FEniCS installation found on system. Please install FEniCS and check the installation.\n\n"
-                  "You can check this by running the command\n\n"
-                  "python3 -c 'from fenics import *'\n\n"
-                  "Please check https://fenicsproject.org/download/ for installation guidance.\n"
-                  "The installation will continue, but please be aware that your installed version of the "
-                  "fenics-adapter might not work as expected.")
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
@@ -39,6 +30,17 @@ setup(name='fenicsprecice',
       author_email='info@precice.org',
       license='LGPL-3.0',
       packages=['fenicsprecice'],
-      install_requires=['pyprecice>=3.0.0.0', 'scipy', 'numpy>=1.13.3, <2', 'mpi4py'],
+      setup_requires=['mpi4py<4'],
+      install_requires=['pyprecice>=3.0.0.0', 'scipy', 'numpy>=1.13.3, <2', 'mpi4py<4'],
       test_suite='tests',
       zip_safe=False)
+
+try:
+    from fenics import *
+except ModuleNotFoundError:
+    warnings.warn("No FEniCS installation found on system. Please install FEniCS and check the installation.\n\n"
+                  "You can check this by running the command\n\n"
+                  "python3 -c 'from fenics import *'\n\n"
+                  "Please check https://fenicsproject.org/download/ for installation guidance.\n"
+                  "The installation will continue, but please be aware that your installed version of the "
+                  "fenics-adapter might not work as expected.")


### PR DESCRIPTION
This PR closes https://github.com/precice/fenics-adapter/issues/180.

`setup_requires=['mpi4py<4']` is necessary as this requirement is needed for the imported FEniCS below.