### PR TITLE
Manually install scipy in tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2   
-      - name: Update apt
-      - run:  |
+      - name: Update list of available packages for apt
+        run:  |
           sudo apt update
       - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
         uses: awalsh128/cache-apt-pkgs-action@latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,8 +33,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2      
       - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
-        run:  |
-          apt install -y python3-scipy
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: python3-scipy
+          version: 1.0
       - name: Install fake precice
         run:  |
           mkdir -p precice

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
           apt update
       - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
         run:  |
-          apt install python3-scipy
+          apt install -y python3-scipy
       - name: Install fake precice
         run:  |
           mkdir -p precice

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2      
       - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
         run:  |
-          apt install python3-scipy
+          apt install -y python3-scipy
       - name: Install fake precice
         run:  |
           mkdir -p precice

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,10 @@ jobs:
     container: benjaminrodenberg/fenics
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2      
+        uses: actions/checkout@v2   
+      - name: Update apt
+      - run:  |
+          sudo apt update
       - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,10 +36,8 @@ jobs:
         run:  |
           apt update
       - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: python3-scipy
-          version: 1.0
+        run:  |
+          apt install python3-scipy
       - name: Install fake precice
         run:  |
           mkdir -p precice

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2   
       - name: Update list of available packages for apt
         run:  |
-          sudo apt update
+          apt update
       - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2      
+      - name: Install scipy (see https://github.com/precice/fenics-adapter/issues/189)
+        run:  |
+          apt install python3-scipy
       - name: Install fake precice
         run:  |
           mkdir -p precice


### PR DESCRIPTION
The goal of this fix is to bring the test back to a working state. On the long run the plan is to modernize the testing infrastructure (see #189 and #177).

The approach implemented in this PR is problematic. Ideally the python package should define the dependency on scipy on its own and the installation of scipy should happen automatically.