### PR TITLE
Restrict SciPy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # FEniCS-preCICE adapter changelog
 
+## develop
+
+* Set required version of `scipy` to `<1.15.0` to prevent failing tests because of a required module that is not found for later versions of scipy. [#195](https://github.com/precice/fenics-adapter/pull/195)
+
 ## v2.2.0
 
 * Use `copy(deepcopy=True)` when checkpointing to make checkpointing more user-friendly and secure. IMPORTANT: might increase runtime, please open an issue if you face serious problems. [#172](https://github.com/precice/fenics-adapter/pull/172)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(name='fenicsprecice',
       author_email='info@precice.org',
       license='LGPL-3.0',
       packages=['fenicsprecice'],
-      install_requires=['pyprecice>=3.0.0.0', 'scipy', 'numpy>=1.13.3, <2', 'mpi4py<4'],
+      install_requires=['pyprecice>=3.0.0.0', 'scipy<1.15.0', 'numpy>=1.13.3, <2', 'mpi4py<4'],
       test_suite='tests',
       zip_safe=False)


### PR DESCRIPTION
A temporary workaround for https://github.com/precice/fenics-adapter/issues/194.

*edit* Closes #194 