### PR TITLE
Migrate the documentation from the website repository

### DIFF
--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -30,7 +30,7 @@ The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE l
 
 ### Use `pip`
 
-The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings, run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
+The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings, run `pip3 install fenicsprecice` in a [virtual environment](https://docs.python.org/3/library/venv.html#creating-virtual-environments) to install the adapter via your Python package manager.
 
 ### Use `conda` (or `mamba`)
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -1,0 +1,25 @@
+---
+title: The FEniCS adapter
+permalink: adapter-fenics.html
+keywords: adapter, fenics
+summary: "A python package providing a preCICE-adapter for the open source computing platform FEniCS."
+---
+
+## FEniCS adapter
+
+For details on installation and usage of the adapter, please refer to its github repository [`precice/fenics-adapter`](https://github.com/precice/fenics-adapter).
+
+You may also refer to the following tutorial cases using the FEniCS adapter:
+
+* Solving the heat equation in a partitioned fashion
+* Flow over plate
+* Perpendicular flap
+* Cylinder with flap
+
+## How to cite
+
+We are currently working on an up-to-date reference paper. Until then, please cite this adapter by referring to its github repository [`precice/fenics-adapter`](https://github.com/precice/fenics-adapter).
+
+## Related literature
+
+[1] Richard Hertrich. Partitioned fluid structure interaction: Coupling FEniCS and OpenFOAM via preCICE. Bachelor's thesis, Munich School of Engineering, Technical University of Munich, 2019.

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -5,15 +5,26 @@ keywords: adapter, fenics
 summary: "A general adapter for the open source computing platform FEniCS"
 ---
 
-## What is FEniCS ?
+## What is FEniCS
 
 From the FEniCS website: _FEniCS is a popular open-source (LGPLv3) computing platform for solving partial differential equations (PDEs). FEniCS enables users to quickly translate scientific models into efficient finite element code. With the high-level Python and C++ interfaces to FEniCS, it is easy to get started, but FEniCS offers also powerful capabilities for more experienced programmers. FEniCS runs on a multitude of platforms ranging from laptops to high-performance clusters._ More details can be found at [fenicsproject.org](https://fenicsproject.org/).
+
+## How to get FEniCS
+
+You can install FEniCS on your system by several ways as mentioned on [fenicsproject.org](https://fenicsproject.org/download/). The simplest way to install FEniCS on Ubuntu is using the official PPA repository of FEniCS:
+
+```bash
+sudo apt install software-properties-common
+sudo add-apt-repository ppa:fenics-packages/fenics
+sudo apt-get update
+sudo apt-get install --no-install-recommends fenics
+```
 
 ## Aim of this adapter
 
 This adapter supports the Python interface of FEniCS and offers an API that allows the user to use FEniCS-style data structures for solving coupled problems. We provide usage example for the adapter for heat transport, conjugate heat transfer and fluid-structure interaction. However, the adapter is designed in a general fashion and can be used to couple any code using the FEniCS library.
 
-## How to install the adapter?
+## How to install the adapter
 
 The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE language bindings for Python. The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings one can simply run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
 
@@ -30,7 +41,7 @@ The following tutorials can be used as a usage example for the FEniCS adapter:
 
 For more details please consult the references given in the [reference section](#related-literature).
 
-## How can I use my own solver with the adapter ?
+## How can I use my own solver with the adapter
 
 The FEniCS adapter does not couple your code out-of-the-box, but you have to call the adapter API from within your code. You can use the tutorials from above as an example. The API of the adapter and the design is explained and usage examples are given in the [reference paper](#how-to-cite).
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -6,19 +6,20 @@ summary: "A general adapter for the open source computing platform FEniCS"
 ---
 
 ## What is FEniCS ?
+
 From the FEniCS website: _FEniCS is a popular open-source (LGPLv3) computing platform for solving partial differential equations (PDEs). FEniCS enables users to quickly translate scientific models into efficient finite element code. With the high-level Python and C++ interfaces to FEniCS, it is easy to get started, but FEniCS offers also powerful capabilities for more experienced programmers. FEniCS runs on a multitude of platforms ranging from laptops to high-performance clusters._ More details can be found at [fenicsproject.org](https://fenicsproject.org/).
 
-
 ## Aim of this adapter
+
 This adapter supports the Python interface of FEniCS and offers an API that allows the user to use FEniCS-style data structures for solving coupled problems. We provide usage example for the adapter for heat transport, conjugate heat transfer and fluid-structure interaction. However, the adapter is designed in a general fashion and can be used to couple any code using the FEniCS library.
 
-
 ## How to install the adapter?
+
 The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE language bindings for Python. The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings one can simply run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
 
 Please refer to the installation instructions provided [here](https://github.com/precice/fenics-adapter#installing-the-package) for alternative installation procedures.
 
-## Examples for coupled codes.
+## Examples for coupled codes
 
 The following tutorials can be used as a usage example for the FEniCS adapter:
 
@@ -28,9 +29,11 @@ The following tutorials can be used as a usage example for the FEniCS adapter:
 * Cylinder with flap (structure problem solved via FEniCS), see [2]
 
 ## How can I use my own solver with the adapter ?
+
 The FEniCS adapter does not couple your code out-of-the-box, but you have to call the adapter API from within your code. You can use the tutorials from above as an example. The API of the adapter and the design is explained and usage examples are given in [1].
 
 ## You need more information?
+
 Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [gitter](https://gitter.im/precice/Lobby).
 
 ## How to cite
@@ -41,4 +44,3 @@ If you are using our adapter, please consider citing our paper "FEniCS-preCICE: 
 
 [1] Benjamin Rodenberg, Ishaan Desai, Richard Hertrich, Alexander Jaust, Benjamin Uekermann. FEniCS-preCICE: Coupling FEniCS to other Simulation Software. [preprint on arXiv, arxiv.org/abs/2103.11191](https://arxiv.org/abs/2103.11191), 2021  
 [2] Richard Hertrich. Partitioned fluid structure interaction: Coupling FEniCS and OpenFOAM via preCICE. Bachelor's thesis, Munich School of Engineering, Technical University of Munich, 2019.
-

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -58,7 +58,7 @@ The FEniCS adapter does not couple your code out-of-the-box, but you have to cal
 
 ## You need more information?
 
-Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [Matrix](https://matrix.to/#/#precice_Lobby:gitter.im).
+Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [Matrix]({{ site.matrix_url }}).
 
 ## How to cite
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -2,19 +2,36 @@
 title: The FEniCS adapter
 permalink: adapter-fenics.html
 keywords: adapter, fenics
-summary: "A python package providing a preCICE-adapter for the open source computing platform FEniCS."
+summary: "A general adapter for the open source computing platform FEniCS"
 ---
 
-## FEniCS adapter
+## What is FEniCS ?
+From the FEniCS website: _FEniCS is a popular open-source (LGPLv3) computing platform for solving partial differential equations (PDEs). FEniCS enables users to quickly translate scientific models into efficient finite element code. With the high-level Python and C++ interfaces to FEniCS, it is easy to get started, but FEniCS offers also powerful capabilities for more experienced programmers. FEniCS runs on a multitude of platforms ranging from laptops to high-performance clusters._ More details can be found at [fenicsproject.org](https://fenicsproject.org/).
 
-For details on installation and usage of the adapter, please refer to its github repository [`precice/fenics-adapter`](https://github.com/precice/fenics-adapter).
 
-You may also refer to the following tutorial cases using the FEniCS adapter:
+## Aim of this adapter
+This adapter supports the Python interface of FEniCS and offers an API that allows the user to use FEniCS-style data structures for solving coupled problems. We provide usage example for the adapter for heat transport, conjugate heat transfer and fluid-structure interaction. However, the adapter is designed in a general fashion and can be used to couple any code using the FEniCS library.
 
-* Solving the heat equation in a partitioned fashion
-* Flow over plate
-* Perpendicular flap
-* Cylinder with flap
+
+## How to install the adapter?
+The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE language bindings for Python. The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings one can simply run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
+
+Please refer to the installation instructions provided [here](https://github.com/precice/fenics-adapter#installing-the-package) for alternative installation procedures.
+
+## Examples for coupled codes.
+
+The following tutorials can be used as a usage example for the FEniCS adapter:
+
+* Solving the heat equation in a partitioned fashion (heat equation solved via FEniCS for both participants)
+* Flow over plate (heat equation solved via FEniCS for solid participant)
+* Perpendicular flap (structure problem solved via FEniCS)
+* Cylinder with flap (structure problem solved via FEniCS)
+
+## How can I use my own solver with the adapter ?
+The FEniCS adapter does couple your code out-of-the-box, but you have to call the adapter API from within your code. You can use the tutorials from above as an example.
+
+## You need more information?
+The documentation of the FEniCS adapter is currently very minimal. Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [gitter](https://gitter.im/precice/Lobby). A paper with a detailed description of the adapter is in preparation.
 
 ## How to cite
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -23,14 +23,16 @@ Please refer to the installation instructions provided [here](https://github.com
 
 The following tutorials can be used as a usage example for the FEniCS adapter:
 
-* Solving the heat equation in a partitioned fashion (heat equation solved via FEniCS for both participants), see [1]
-* Flow over plate (heat equation solved via FEniCS for solid participant), see [1]
-* Perpendicular flap (structure problem solved via FEniCS), see [1, 2]
-* Cylinder with flap (structure problem solved via FEniCS), see [2]
+* Solving the heat equation in a partitioned fashion (heat equation solved via FEniCS for both participants)
+* Flow over plate (heat equation solved via FEniCS for solid participant)
+* Perpendicular flap (structure problem solved via FEniCS)
+* Cylinder with flap (structure problem solved via FEniCS)
+
+For more details please consult the references given in the [reference section](#related-literature).
 
 ## How can I use my own solver with the adapter ?
 
-The FEniCS adapter does not couple your code out-of-the-box, but you have to call the adapter API from within your code. You can use the tutorials from above as an example. The API of the adapter and the design is explained and usage examples are given in [1].
+The FEniCS adapter does not couple your code out-of-the-box, but you have to call the adapter API from within your code. You can use the tutorials from above as an example. The API of the adapter and the design is explained and usage examples are given in the [reference paper](#how-to-cite).
 
 ## You need more information?
 
@@ -38,9 +40,69 @@ Please don't hesitate to ask questions about the FEniCS adapter on [discourse](h
 
 ## How to cite
 
-If you are using our adapter, please consider citing our paper "FEniCS-preCICE: Coupling FEniCS to other Simulation Software" [1].
+If you are using our adapter, please consider citing our paper:
+
+{% for pub in site.publications %}
+
+{% if pub.title == "FEniCS–preCICE: Coupling FEniCS to other simulation software" %}
+
+<div class="row">
+<div class="col-md-10 col-md-offset-1">
+  <div class="panel panel-primary panel-precice">
+    <div class="panel-heading-precice">
+      <strong>{{ pub.title }}</strong>
+    </div>
+    <div class="panel-body">
+      <p>
+        <em>{{ pub.authors }}</em>,
+        {{ pub.journal.name }},
+        Volume {{ pub.journal.volume }},
+        {{ pub.journal.publisher }},
+        {{ pub.year }},
+        <a href="https://www.doi.org/{{pub.doi}}">doi:{{pub.doi}}</a>.
+      </p>
+      <a href="{{pub.pub-url}}">Publisher's site</a>&nbsp;&nbsp;
+      <a href="assets/{{ pub.bibtex }}">Download BibTeX &nbsp;<i class="fas fa-download"></i></a>
+    </div>
+  </div>
+</div>
+</div>
+
+{% endif %}
+
+{% endfor %}
 
 ## Related literature
 
-[1] Benjamin Rodenberg, Ishaan Desai, Richard Hertrich, Alexander Jaust, Benjamin Uekermann. FEniCS-preCICE: Coupling FEniCS to other Simulation Software. [preprint on arXiv, arxiv.org/abs/2103.11191](https://arxiv.org/abs/2103.11191), 2021  
-[2] Richard Hertrich. Partitioned fluid structure interaction: Coupling FEniCS and OpenFOAM via preCICE. Bachelor's thesis, Munich School of Engineering, Technical University of Munich, 2019.
+{% assign years = site.publications | group_by:"year" | sort:"title" %}
+{% for year in years reversed %}
+
+<div class="row">
+{% for pub in year.items %}
+{% if pub.tag contains "fenics" %}
+<div class="col-md-10 col-md-offset-1">
+  <div class="panel panel-primary panel-precice">
+    <div class="panel-heading-precice">
+      <strong>{{ pub.title }}</strong>
+    </div>
+    <div class="panel-body">
+      <p>
+        <em>{{ pub.authors }}</em>
+        {% if pub.journal.name %}{{ pub.journal.name }}, {% endif %}
+        {% if pub.journal.volume %}Volume {{ pub.journal.volume }}, {% endif %}
+        {% if pub.journal.publisher %}{{ pub.journal.publisher }}, {% endif %}
+        {{ pub.year }}{% if pub.doi %}, <a href="https://www.doi.org/{{pub.doi}}">doi:{{pub.doi}}</a>{% endif %}.
+      </p>
+      {% if pub.pub-url %}
+      <a href="{{pub.pub-url}}">Publisher's site</a>&nbsp;&nbsp;
+      {% endif %}
+      {% if pub.bibtex %}
+      <a href="assets/{{ pub.bibtex }}">Download BibTeX &nbsp;<i class="fas fa-download"></i></a>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endif %}
+{% endfor %}
+</div>
+{% endfor %}

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -48,6 +48,7 @@ The following tutorials can be used as a usage example for the FEniCS adapter:
 * Flow over plate (heat equation solved via FEniCS for solid participant)
 * Perpendicular flap (structure problem solved via FEniCS)
 * Cylinder with flap (structure problem solved via FEniCS)
+* Solving a chemical reaction process in a flow simulation (both reaction-advection-diffusion and fluid flow solved via FEniCS)
 
 For more details please consult the references given in the [reference section](#related-literature).
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -30,7 +30,7 @@ The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE l
 
 ### Use `pip`
 
-The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings one can simply run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
+The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings, run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
 
 ### Use `conda`
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -32,9 +32,9 @@ The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE l
 
 The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings, run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
 
-### Use `conda`
+### Use `conda` (or `mamba`)
 
-You can alternatively use `conda` to install the adapter. Please refer to [`conda-forge/fenicsprecice`](https://anaconda.org/conda-forge/fenicsprecice) for installation instructions. Bonus, if you use `conda`: You don't have to worry about the dependencies, because `conda` takes care of this for you.
+You can alternatively use `conda` (or `mamba`) to install the adapter. We recommend using [Miniforge](https://conda-forge.org/download/) (see https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us for reasons why). Please refer to [`conda-forge/fenicsprecice`](https://github.com/conda-forge/fenicsprecice-feedstock) for installation instructions. Added advantage of using `conda`: you do not have to worry about the dependencies, because `conda` takes care of this for you.
 
 ### Something special?
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -26,7 +26,17 @@ This adapter supports the Python interface of FEniCS and offers an API that allo
 
 ## How to install the adapter
 
-The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE language bindings for Python. The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings one can simply run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
+The adapter requires FEniCS and preCICE version 2.0 or greater and the preCICE language bindings for Python.
+
+### Use `pip`
+
+The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). After installing preCICE and the python language bindings one can simply run `pip3 install --user fenicsprecice` to install the adapter via your Python package manager.
+
+### Use `conda`
+
+You can alternatively use `conda` to install the adapter. Please refer to [`conda-forge/fenicsprecice`](https://anaconda.org/conda-forge/fenicsprecice) for installation instructions. Bonus, if you use `conda`: You don't have to worry about the dependencies, because `conda` takes care of this for you.
+
+### Something special?
 
 Please refer to the installation instructions provided [here](https://github.com/precice/fenics-adapter#installing-the-package) for alternative installation procedures.
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -58,7 +58,7 @@ The FEniCS adapter does not couple your code out-of-the-box, but you have to cal
 
 ## You need more information?
 
-Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [gitter](https://gitter.im/precice/Lobby).
+Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [Matrix](https://matrix.to/#/#precice_Lobby:gitter.im).
 
 ## How to cite
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -34,11 +34,11 @@ The adapter is [published on PyPI](https://pypi.org/project/fenicsprecice/). Aft
 
 ### Use `conda` (or `mamba`)
 
-You can alternatively use `conda` (or `mamba`) to install the adapter. We recommend using [Miniforge](https://conda-forge.org/download/) (see https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us for reasons why). Please refer to [`conda-forge/fenicsprecice`](https://github.com/conda-forge/fenicsprecice-feedstock) for installation instructions. Added advantage of using `conda`: you do not have to worry about the dependencies, because `conda` takes care of this for you.
+You can alternatively use `conda` (or `mamba`) to install the adapter. We recommend using [Miniforge](https://conda-forge.org/download/) ([read why](https://www.fz-juelich.de/en/rse/the_latest/the-anaconda-is-squeezing-us)). Please refer to [`conda-forge/fenicsprecice`](https://github.com/conda-forge/fenicsprecice-feedstock) for installation instructions. Added advantage of using `conda`: you do not have to worry about the dependencies, because `conda` takes care of this for you.
 
 ### Something special?
 
-Please refer to the installation instructions provided [here](https://github.com/precice/fenics-adapter#installing-the-package) for alternative installation procedures.
+Please refer to the installation instructions provided [in the `README.md`](https://github.com/precice/fenics-adapter#installing-the-package) for alternative installation procedures.
 
 ## Examples for coupled codes
 

--- a/docs/adapter-fenics.md
+++ b/docs/adapter-fenics.md
@@ -22,21 +22,23 @@ Please refer to the installation instructions provided [here](https://github.com
 
 The following tutorials can be used as a usage example for the FEniCS adapter:
 
-* Solving the heat equation in a partitioned fashion (heat equation solved via FEniCS for both participants)
-* Flow over plate (heat equation solved via FEniCS for solid participant)
-* Perpendicular flap (structure problem solved via FEniCS)
-* Cylinder with flap (structure problem solved via FEniCS)
+* Solving the heat equation in a partitioned fashion (heat equation solved via FEniCS for both participants), see [1]
+* Flow over plate (heat equation solved via FEniCS for solid participant), see [1]
+* Perpendicular flap (structure problem solved via FEniCS), see [1, 2]
+* Cylinder with flap (structure problem solved via FEniCS), see [2]
 
 ## How can I use my own solver with the adapter ?
-The FEniCS adapter does couple your code out-of-the-box, but you have to call the adapter API from within your code. You can use the tutorials from above as an example.
+The FEniCS adapter does not couple your code out-of-the-box, but you have to call the adapter API from within your code. You can use the tutorials from above as an example. The API of the adapter and the design is explained and usage examples are given in [1].
 
 ## You need more information?
-The documentation of the FEniCS adapter is currently very minimal. Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [gitter](https://gitter.im/precice/Lobby). A paper with a detailed description of the adapter is in preparation.
+Please don't hesitate to ask questions about the FEniCS adapter on [discourse](https://precice.discourse.group/) or in [gitter](https://gitter.im/precice/Lobby).
 
 ## How to cite
 
-We are currently working on an up-to-date reference paper. Until then, please cite this adapter by referring to its github repository [`precice/fenics-adapter`](https://github.com/precice/fenics-adapter).
+If you are using our adapter, please consider citing our paper "FEniCS-preCICE: Coupling FEniCS to other Simulation Software" [1].
 
 ## Related literature
 
-[1] Richard Hertrich. Partitioned fluid structure interaction: Coupling FEniCS and OpenFOAM via preCICE. Bachelor's thesis, Munich School of Engineering, Technical University of Munich, 2019.
+[1] Benjamin Rodenberg, Ishaan Desai, Richard Hertrich, Alexander Jaust, Benjamin Uekermann. FEniCS-preCICE: Coupling FEniCS to other Simulation Software. [preprint on arXiv, arxiv.org/abs/2103.11191](https://arxiv.org/abs/2103.11191), 2021  
+[2] Richard Hertrich. Partitioned fluid structure interaction: Coupling FEniCS and OpenFOAM via preCICE. Bachelor's thesis, Munich School of Engineering, Technical University of Munich, 2019.
+


### PR DESCRIPTION
Similarly to PRs for the code_aster (https://github.com/precice/code_aster-adapter/pull/30) and CalculiX (https://github.com/precice/calculix-adapter/pull/150) adapters, this PR migrates the documentation files and the respective Git history from the website repository (https://github.com/precice/precice.github.io/tree/70b5adac8b41d73c43642499626324b7f4a4c19e), to keep the documentation close to the code.

I have curated the history to:

- Prepend a `[DOCS]` in all ported commits
- Add links to the original commits and adapt the links to PRs/issues
- Squash some feature + following linter-fix commits

Similarly to other PRs, I recommend doing a "Rebase and merge", to keep the history distinct and on top of what there is already in this repository.

Once merged, there is a follow-up PR on the website to remove the content: https://github.com/precice/precice.github.io/pull/907