### PR TITLE
Add a workflow for triggering the system tests

### DIFF
--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -1,0 +1,13 @@
+name: System tests
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  run-system-tests:
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
+    uses: precice/tutorials/.github/workflows/system-tests.yml@develop
+    with:
+      suites: fenics-adapter
+      build_args: FENICS_ADAPTER_PR:${{ github.event.number }},FENICS_ADAPTER_REF:${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Adds a GHA workflow to trigger the system tests (`fenics-adapter` test suite) whenever the `trigger-system-tests` label is added.

I understand that there is an implicit convention on starting each workflow name with a verb, so this is named `run-system-tests.yml` (instead of `system-tests.yml` that I used elsewhere).

I disabled the results comparison for the elastic-tube-3d in https://github.com/precice/tutorials/commit/58ad27c9e2024b2f6d316621984347019c8724dc, for the known issue with values close to zero. This is independent of this repository.