### PR TITLE
Add a workflow for updating the website

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,22 @@
+name: Update website
+on:
+  push:
+    branches:
+      - 'develop'
+    paths:
+      - 'docs/**'
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    env:
+      WORKFLOW_FILENAME: update-submodules.yml
+    steps:
+    - name: Trigger workflow
+      run: |
+        curl \
+        --request POST \
+        --url https://api.github.com/repos/precice/precice.github.io/actions/workflows/$WORKFLOW_FILENAME/dispatches \
+        --header "authorization: token ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}" \
+        --header "Accept: application/vnd.github.v3+json" \
+        --data '{"ref":"master"}' \
+        --fail


### PR DESCRIPTION
Similarly to the [FEniCSx adapter](https://github.com/precice/fenicsx-adapter/blob/develop/.github/workflows/update-website.yml) and other repositories, this PR adds an `update-website.yml` workflow to trigger the respective workflow of the website repository to update the Git modules.

It is not yet final whether we will need this in the Hugo port of the website or not, but I suggest adding it for consistency, and since this is the currently employed system. We can remove it later again, if needed.