### PR TITLE
Make check-links.yml workflow manual

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,5 @@
 name: Lint scripts and docs
-on: [push, pull_request]
+on: workflow_dispatch
 jobs:
   check_markdown_files:
     name: Lint scripts and docs


### PR DESCRIPTION
The `check-links.yml` workflow is quite fragile, as pages accessible to humans can (temporarily) be unreachable or block connections from GitHub. While we previously had such a workflow in the website repository, this was causing similar issues there.

As a workaround, I suggest keeping the workflow, but only allowing manual execution. This could be useful to discover some broken links, but would not interfere with the rest of the CI.